### PR TITLE
Move JSONP callback support to /search endpoint and update sample

### DIFF
--- a/lodmill-ui/doc/autocomplete-remote.html
+++ b/lodmill-ui/doc/autocomplete-remote.html
@@ -13,12 +13,16 @@
 			$input.autocomplete({
 				source : function(request, response) {
 					$.ajax({
-						// Get the autocomplete data from a remote URL 
-						// (i.e. a different server from the one that 
-						// serves this HTML) by using JSONP: 
-						url : "http://demo.lobid.org/autocomplete",
+						// Get the autocomplete data from a remote URL
+						// (i.e. a different server from the one that
+						// serves this HTML) by using JSONP:
+						url : "http://demo.lobid.org/search",
 						dataType : "jsonp",
-						data : { term : request.term },
+						data : {
+							query : request.term,
+							format : "short",
+							index : "gnd-index" // lobid-index, lobid-orgs-index
+						},
 						success : function(data) {
 							response(data);
 						}


### PR DESCRIPTION
This allows JSONP autocomplete API clients to use a specific index,
and simplifies the API by using the general search endpoint config.
