### PR TITLE
Finish zvdd collection transformation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist
 lodmill-ui/.classpath
 test.*
 *.dot*
+.project
+.settings

--- a/lodmill-rd/doc/zvdd/collections/mapping.textile
+++ b/lodmill-rd/doc/zvdd/collections/mapping.textile
@@ -22,7 +22,7 @@
 |992  .b|146| ignore. link to collection |  | ignore |
 |980  .a|146| ignore | |  ignore |
 |992  .c|146| ignore | |  ignore |
-|001|146| ignore . internal ID. Good for minting URIs| minting URI | done |
+|001|146| ignore . internal ID. Good for minting URIs| minting URI | - |
 |992  .a|146| ID of collection .  Good for minting URIs| minting URI | done |
 |260  .a|146| ignore. Place of creation| | ignore |
 |082  .a|131| ddc | dct:subject (uris!) | done |

--- a/lodmill-rd/doc/zvdd/mismatching_collection-IDs.textile
+++ b/lodmill-rd/doc/zvdd/mismatching_collection-IDs.textile
@@ -1,0 +1,12 @@
+IDs used in titles | IDs used in collections
+collection:die_arbeit.fes.bn.de | collection:sozialistische_mitteilungen.fes.bn.de
+collection:digitale_sammlungen.uni.bn.de | collection:digizeit.digizeitev.goe.de
+collection:digiwunsch.sub.goe.de | fehlen! s. http://digreg.mathguide.de/cgi-bin/ssgfi/anzeige.pl?db=reg&id=PRO&nr=030769&ew=SSGFI
+collection:einblattdrucke_vd17.gbv.goe.de | collection:einblattdrucke.vd17.oo.de
+collection:exilzeitschriften.d-nb.f.de | collection:exil-zeitschriften.ddb.f.de
+collection:juedische_periodika.d-nb.f.de | collection:juedische_periodika.ddb.f.de
+collection:juedische_periodika.rwth.ac.de | missing !
+collection:sammlung_ponickau.ulb.hal.de | missing !
+collection:sozialistische_monatshefte.fes.bn.de | missing !
+collection:verteilte_rechtsquellen.d-nb.f.de | collection:verteilte_rechtsquellen.ddb.f.de
+collection:zvdd.gbv.goe.de | missing !

--- a/lodmill-rd/src/main/resources/morph-zvdd_collection-rdfld.xml
+++ b/lodmill-rd/src/main/resources/morph-zvdd_collection-rdfld.xml
@@ -24,9 +24,7 @@
 				<data source="5203 .a" name="http://purl.org/dc/elements/1.1/description"/>
 				<data source="522  .a" name="http://purl.org/dc/terms/spatial"/>
 				<data source="546  .a" name="http://purl.org/dc/terms/language">
-						<!-- @TODO split first 2 digits. Mapping 2 digits to three digits As it is, this is NOT 
-								iso639-2. -->
-						<regexp match="(\w{2})" format="http://id.loc.gov/vocabulary/iso639-2/${1}"/>
+						<regexp match="(\w{2})" format="http://id.loc.gov/vocabulary/iso639-1/${1}"/>
 				</data>
 				<data source="65007.a" name="http://purl.org/dc/elements/1.1/subject"/>
 				<combine name="http://xmlns.com/foaf/spec/#term_homepage" value="${hp-url}"
@@ -71,7 +69,10 @@
 						</data>
 				</combine>
 				<data source="992  .a" name="subject">
-						<regexp match="(.*:.*\..*)" format="http://lobid.org/zvdd/hbz/${1}"/><!-- some sanitizing -->
+						<regexp match=".*:(.*\..*)" format="http://lobid.org/zvdd/hbz/${1}"/><!-- some sanitizing -->
+				</data>
+				<data source="992  .a" name="http://purl.org/dc/elements/1.1/subject">
+						<regexp match="(.*:.*\..*)" format="${1}"/>
 				</data>
 				<!-- Leave all other fields untransformed: <data source="_else"/> -->
 		</rules>


### PR DESCRIPTION
- allow URIs instead of only URL
- subject URI taken from 992
- subject URI need not to be the first parsed line
- add textile describing missing collections
