### PR TITLE
Tweak search result presentation

### DIFF
--- a/lodmill-ui/app/views/index.scala.html
+++ b/lodmill-ui/app/views/index.scala.html
@@ -90,13 +90,28 @@
     <h1>@docs.size() @if(docs.size() == 1) { Document } else { Documents } @if(query!=""){ for '@query' }</h1>
     
     @for(doc <- docs) {
-        <h2>@doc.id</h2>
-        <dl>
-        	<dt><b>JLD</b></dt><dd>@doc.source</dd>
-        	<dt><b>NT</b></dt><dd>@doc.as(Format.N_TRIPLE)</dd>
-        	<dt><b>N3</b></dt><dd>@doc.as(Format.N3)</dd>
-        	<dt><b>TTL</b></dt><dd>@doc.as(Format.TURTLE)</dd>
-        </dl>
+		@defining(doc.id.split("/").last) { id =>
+		<h2><a href="@doc.id">@doc.id</a></h2>
+		<ul class="nav nav-tabs" id="@id-serializations">
+		  <li><a href="#@id-jld" data-toggle="tab">JLD</a></li>
+		  <li><a href="#@id-nt" data-toggle="tab">NT</a></li>
+		  <li><a href="#@id-n3" data-toggle="tab">N3</a></li>
+		  <li><a href="#@id-ttl" data-toggle="tab">TTL</a></li>
+		</ul>
+
+		<div class="tab-content">
+		  <div class="tab-pane active" id="@id-jld"><pre>@doc.source</pre></div>
+		  <div class="tab-pane" id="@id-nt"><pre>@doc.as(Format.N_TRIPLE)</pre></div>
+		  <div class="tab-pane" id="@id-n3"><pre>@doc.as(Format.N3)</pre></div>
+		  <div class="tab-pane" id="@id-ttl"><pre>@doc.as(Format.TURTLE)</pre></div>
+		</div>
+
+		<script>
+		  $(function () {
+		    $('#@id-serializations a:first').tab('show');
+		  })
+		</script>
+		}
     }
 
 }


### PR DESCRIPTION
- Wrap RDF in `pre` tags
- Turn document ID headers into links
- Use tab groups for different serializations

Deployed for testing at http://api.lobid.org/
