### PR TITLE
Add additional route for simple queries with defaults

### DIFF
--- a/lodmill-ui/app/views/index.scala.html
+++ b/lodmill-ui/app/views/index.scala.html
@@ -10,7 +10,7 @@
 
     <h1>@Document.ES_CLUSTER_NAME on @Document.ES_SERVER.address()</h1>
 
-    <p>API sample usage: <pre>GET /id/9783458171652 ; GET /author/Abramson ; GET /author/Abramson?format=full&index=gnd-index ; GET /search?format=full&index=lobid-index&category=author&query=Abramson</pre></p>
+    <p>API sample usage: <pre>GET /id/9783458171652 ; GET /author/Abramson ; GET /author/Abramson?format=page&index=gnd-index ; GET /search?format=full&index=lobid-index&category=author&query=Abramson</pre></p>
 
 	<form action="@routes.Application.config(index, category, resultFormat)" class="form-horizontal" method="GET">
 		<!-- TODO: create a custom tag and extract the common code of these 3 option divs: -->

--- a/lodmill-ui/conf/routes
+++ b/lodmill-ui/conf/routes
@@ -9,7 +9,7 @@ GET     /                           controllers.Application.index()
 GET     /assets/*file               controllers.Assets.at(path="/public", file)
 
 GET     /search                     controllers.Application.search(index: String, category: String, format: String, query: String)
-GET     /:category/:query           controllers.Application.search(index: String ?= "lobid-index", category: String, format: String ?= "page", query: String)
+GET     /:category/:query           controllers.Application.search(index: String ?= "lobid-index", category: String, format: String ?= "full", query: String)
 
 GET     /config                     controllers.Application.config(index: String, category: String, format: String)
 


### PR DESCRIPTION
Allows queries like `GET /id/9783458171652`, `GET /author/Abramson`
(index defaults to `lobid-index`, result defaults to `page`, can
both be specified additionally, see sample on index page).

Deployed for testing at http://api.lobid.org/
