### PR TITLE
Make HDFS to ES indexing tests self-containd and add them to CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ lodmill*.jar
 *.xsd
 .cache
 lodmill-ui/data/
+lodmill-ld/data/
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
   - wget http://downloads.typesafe.com/play/${PLAY_VERSION}/play-${PLAY_VERSION}.zip
   - unzip -q play-${PLAY_VERSION}.zip
 script:
+  - umask 0022
   - mvn test -e -q --settings settings.xml
   - cd lodmill-ui
   - ../play-${PLAY_VERSION}/play test

--- a/lodmill-ld/pom.xml
+++ b/lodmill-ld/pom.xml
@@ -116,13 +116,14 @@
 		        <artifactId>maven-surefire-plugin</artifactId>
 		        <version>2.12.4</version>
 		        <configuration>
-					<test>org.lobid.lodmill.UnitTests</test>
+					<test>org.lobid.lodmill.AllTests</test>
 		        </configuration>
 			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -130,7 +131,21 @@
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>
-		
+
+		<!-- Transitive dependencies for Hadoop minicluster -->
+		<dependency>
+			<groupId>javax.ws.rs</groupId>
+			<artifactId>jsr311-api</artifactId>
+			<version>1.1.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.5.11</version>
+		</dependency>
+		<!-- End transitive dependencies for Hadoop minicluster -->
+
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-core</artifactId>
@@ -138,10 +153,6 @@
 			<type>jar</type>
 			<scope>compile</scope>
 			<exclusions>
-				<exclusion>
-					<artifactId>commons-logging</artifactId>
-					<groupId>commons-logging</groupId>
-				</exclusion>
 				<exclusion>
 					<groupId>org.codehaus.jackson</groupId>
 					<artifactId>jackson-mapper-asl</artifactId>
@@ -155,12 +166,6 @@
 			<version>1.0.3</version>
 			<type>jar</type>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<artifactId>slf4j-api</artifactId>
-					<groupId>org.slf4j</groupId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -169,12 +174,6 @@
 			<version>1.0.0-SNAPSHOT</version>
 			<classifier>hadoop1</classifier>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<artifactId>log4j</artifactId>
-					<groupId>log4j</groupId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		
 		<dependency>

--- a/lodmill-ld/src/test/java/org/lobid/lodmill/IntegrationTests.java
+++ b/lodmill-ld/src/test/java/org/lobid/lodmill/IntegrationTests.java
@@ -5,8 +5,6 @@ package org.lobid.lodmill;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.lobid.lodmill.hadoop.IndexFromHdfsInElasticSearchTests;
-import org.lobid.lodmill.sparql.FourStoreTests;
-import org.lobid.lodmill.sparql.GutenbergTests;
 
 /**
  * Main test suite for all integration tests.
@@ -14,8 +12,7 @@ import org.lobid.lodmill.sparql.GutenbergTests;
  * @author Fabian Steeg (fsteeg)
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ IndexFromHdfsInElasticSearchTests.class,
-		GutenbergTests.class, FourStoreTests.class })
+@Suite.SuiteClasses({ IndexFromHdfsInElasticSearchTests.class })
 public final class IntegrationTests {
 	/* Suite class, groups tests via annotation above */
 }

--- a/lodmill-ld/src/test/java/org/lobid/lodmill/sparql/GutenbergTests.java
+++ b/lodmill-ld/src/test/java/org/lobid/lodmill/sparql/GutenbergTests.java
@@ -41,8 +41,8 @@ public final class GutenbergTests {
 
 	private static final String CREATORS = "creators_small.nt";
 	private static final String GRAPH = "http://lobid.org/graph/gutenberg/gnd";
-	private static final String OUT = "bin/new.nt";
-	private static final String MAP_BIN = "bin/map.bin";
+	private static final String OUT = "target/new.nt";
+	private static final String MAP_BIN = "target/map.bin";
 	private static final Logger LOG = LoggerFactory
 			.getLogger(GutenbergTests.class);
 	/* First run, pass '-Xmx3000m -XX:+UseConcMarkSweepGC' as JVM args for Jena */


### PR DESCRIPTION
- Upload test data to a local in-memory Hadoop MiniDFSCluster
- Index test data in a local in-memory elasticsearch node
- Update config files (JUnit, Maven, and Travis setup)
