### PR TITLE
Fix issue for proper cleanup after running cluster tests

### DIFF
--- a/lodmill-ld/src/test/java/org/lobid/lodmill/hadoop/IndexFromHdfsInElasticSearchTests.java
+++ b/lodmill-ld/src/test/java/org/lobid/lodmill/hadoop/IndexFromHdfsInElasticSearchTests.java
@@ -102,8 +102,9 @@ public class IndexFromHdfsInElasticSearchTests extends ClusterMapReduceTestCase 
 		return response;
 	}
 
+	@Override
 	@After
-	public void close() {
+	public void tearDown() {
 		client.admin().indices().prepareDelete().execute().actionGet();
 		node.close();
 		try {


### PR DESCRIPTION
We are running with JUnit 4, but since we extend  `ClusterMapReduceTestCase` we need to actually override `tearDown`
