### PR TITLE
Fix searching for organisations by full lobid URI

### DIFF
--- a/lodmill-ui/app/models/queries/LobidOrganisations.java
+++ b/lodmill-ui/app/models/queries/LobidOrganisations.java
@@ -29,7 +29,8 @@ public class LobidOrganisations {
 
 		@Override
 		public QueryBuilder build(final String queryString) {
-			return matchQuery(fields().get(0), queryString);
+			return matchQuery(fields().get(0),
+					queryString.replace("http://lobid.org/organisation/", ""));
 		}
 
 	}

--- a/lodmill-ui/test/tests/SearchTests.java
+++ b/lodmill-ui/test/tests/SearchTests.java
@@ -121,9 +121,12 @@ public class SearchTests {
 		assertThat(docs.size()).isEqualTo(1);
 	}
 
-	@Test
-	public void searchViaModelOrgId() {
-		final String term = "DE-605";
+	/*@formatter:off*/
+	@Test public void searchViaModelOrgIdShort() { searchOrgById("DE-605"); }
+	@Test public void searchViaModelOrgIdLong() { searchOrgById("http://lobid.org/organisation/DE-605"); }
+	/*@formatter:on*/
+
+	private static void searchOrgById(final String term) {
 		final List<Document> docs =
 				Search.documents(term, Index.LOBID_ORGANISATIONS, Parameter.ID);
 		assertThat(docs.size()).isEqualTo(1);


### PR DESCRIPTION
The full URI is returned by format=ids, so that should work, e.g.
in GET /organisation?id=http://lobid.org/organisation/DE-605

see http://api.lobid.org/organisation?id=http://lobid.org/organisation/DE-605
