### PR TITLE
Update main page for initial beta release

### DIFF
--- a/lodmill-ui/app/views/index.scala.html
+++ b/lodmill-ui/app/views/index.scala.html
@@ -46,7 +46,7 @@
 		</tr>
 		<tr>
 			<td><code>/organisation</td>
-			@defining(("/organisation?id=SzBaU","/organisation/SzBaU")){refs =>
+			@defining(("/organisation?id=DE-605","/organisation/DE-605")){refs =>
 				<td>
 					<a href="@withPage(refs._1)">@refs._1</a> <br/>
 					<a href="@refs._2?format=page">@refs._2</a>
@@ -84,9 +84,13 @@
 			<td>Search all <br/> (nested JSON result)
 		</tr>
 	</table>
+	<h2>Pagination and Limits</h2>
+	<p>All endpoints support pagination via <code>from</code> and <code>size</code> parameters specifying the index to start the result set from (default is 0, must be >= 0), and the size of the result set (default is 50, must be <= 100). Sample request: <a href="/organisation?name=Universität&from=10&size=5&format=ids">/organisation?name=Universität&from=10&size=5&format=ids</a>.</p>
 
-	<p>All endpoints above support pagination via <code>from</code> and <code>size</code> parameters specifying the index to start the result set from (default is 0, must be >= 0), and the size of the result set (default is 50, must be <= 100). Sample request: <a href="/organisation?name=Universität&from=10&size=5&format=ids">/organisation?name=Universität&from=10&size=5&format=ids</a>.</p>
-	<p>In addition to the API above we plan to offer <code>concept</code>, <code>location</code>, and <code>event</code> authority data endpoints. See our <a href="https://github.com/lobid/lodmill/issues?state=open">open issues</a> and <a href="https://github.com/lobid/lodmill/issues/milestones">milestones</a> on GitHub.</p>
+	<h2>Content Negotiation</h2>
+	<p>To return different RDF serializations as the result format (default is JSON-LD), you can specify an accept header, e.g. for N-Triples:</p>
+	<pre>curl --header "Accept: text/plain" http://api.lobid.org/resource/HT002189125</pre>
+	<p>Currently supported: @Serialization.values().map((s:Serialization) => s.name + " " + s.getTypes).mkString(", ")</p>
 
 	<h2>API sample usage: auto-suggest</h2>
 	<p>Type a person's name to get suggestions. Upon selecting a suggestion, the corresponding ID will be inserted. Search will return details on the selected person.</p>
@@ -119,8 +123,6 @@
 		});
 	</script>
 
-	<h2>Content Negotiation</h2>
-	<p>To return different RDF serializations as the result format (default is JSON-LD), you can specify an accept header, e.g. for N-Triples:</p>
-	<pre>curl --header "Accept: text/plain" http://api.lobid.org/resource/HT002189125</pre>
-	<p>Currently supported: @Serialization.values().map((s:Serialization) => s.name + " " + s.getTypes).mkString(", ")</p>
+	<h2>Outlook and Planning</h2>
+	<p>In addition to the API above we plan to offer <code>concept</code>, <code>location</code>, and <code>event</code> authority data endpoints. See our <a href="https://github.com/lobid/lodmill/issues?state=open">open issues</a> and <a href="https://github.com/lobid/lodmill/issues/milestones">milestones</a> on GitHub.</p>
 }

--- a/lodmill-ui/app/views/main.scala.html
+++ b/lodmill-ui/app/views/main.scala.html
@@ -18,16 +18,16 @@
     <body>
       <div class="container-wide">
         <div class="masthead">
-          <ul class="nav nav-pills pull-right">
-            <li class="active"><a href="/">Index</a></li>
-          </ul>
+          <a href="https://github.com/lobid/lodmill"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png" alt="Fork me on GitHub"></a>
           <h1 class="muted"><a href="/">api.lobid.org</a></h1>
-          <span class="label label-important">Important: this is a preview version of api.lobid.org! The data is incomplete and outdated, and the API is still subject to change. It may be slow, unstable or down altogether!</span>
+          <span class="label label-warning">Note:</span> This is a beta version! The data might be outdated and things might still change! Check out our 
+          <a href="https://github.com/lobid/lodmill/issues?labels=bug&milestone=&page=1&state=open">open bugs</a> or report a 
+          <a href="https://github.com/lobid/lodmill/issues/new">new issue</a>.
         </div>
         <div class="content"><hr/> @content <hr/></div>
         <div class="footer">
-          <p>Lobid API | Running with cluster @Search.ES_CLUSTER_NAME on @Search.ES_SERVER.address() |
-            &copy; 2013 <a href="http://www.hbz-nrw.de">Hochschulbibliothekszentrum NRW</a></p>
+          <p>Lobid API | Running on cluster @Search.ES_CLUSTER_NAME |
+            &copy; 2013 <a href="http://www.hbz-nrw.de">hbz — Hochschulbibliothekszentrum NRW</a></p>
         </div>
       </div>
     </body>


### PR DESCRIPTION
This updates the main API documentation page (closes #122).

These changes and the yet unmerged pull requests #116 (new data conversion) and #121 (update queries and views) are deployed to Quaoar. Together, this is our initial beta release. It probably makes sense to merge this after #116 and #121, but @dr0i and @acka47 please check it out and give me your +1s so we can start pointing people to it:

http://api.lobid.org/
