### PR TITLE
Revise content negotiation, result formats, and defaults

### DIFF
--- a/lodmill-ui/app/controllers/Api.java
+++ b/lodmill-ui/app/controllers/Api.java
@@ -41,9 +41,11 @@ public final class Api extends Controller {
 			final String name, // NOPMD
 			final String author, final String subject, final String set,
 			final String format, final int from, final int size) {
-		Logger.debug(String.format(
-				"GET /resource; id: '%s', name: '%s', author: '%s', subject: '%s'", id,
-				name, author, subject));
+		Logger
+				.debug(String
+						.format(
+								"GET /resource; id: '%s', name: '%s', author: '%s', subject: '%s', format: '%s'",
+								id, name, author, subject, format));
 		final Index index = Index.LOBID_RESOURCES;
 		Result result = null;
 		if (defined(id)) {

--- a/lodmill-ui/app/controllers/ResultFormat.java
+++ b/lodmill-ui/app/controllers/ResultFormat.java
@@ -8,8 +8,8 @@ package controllers;
  * @author Fabian Steeg (fsteeg)
  */
 public enum ResultFormat {
-	/** Complete HTML page with search form on top, results at bottom. */
-	PAGE,
+	/** Use content negotiation to determine the actual result format. */
+	NEGOTIATE,
 	/** The full JSON representation from the index. */
 	FULL,
 	/** Short results strings for auto-completion suggestions. */

--- a/lodmill-ui/app/views/docs.scala.html
+++ b/lodmill-ui/app/views/docs.scala.html
@@ -28,7 +28,7 @@
 				case Index.LOBID_ITEMS => {@item(Json.parse(doc.getSource))}
 			}
 		  </div>
-		  <div class="tab-pane" id="@id-jld"><pre>@doc.getSource</pre></div>
+		  <div class="tab-pane" id="@id-jld"><pre>@Json.prettyPrint(Json.parse(doc.getSource))</pre></div>
 		  <div class="tab-pane" id="@id-nt"><pre>@doc.as(Format.N_TRIPLE)</pre></div>
 		  <div class="tab-pane" id="@id-ttl"><pre>@doc.as(Format.TURTLE)</pre></div>
 		</div>

--- a/lodmill-ui/app/views/index.scala.html
+++ b/lodmill-ui/app/views/index.scala.html
@@ -3,13 +3,11 @@
 @import controllers.Serialization
 @import models.Index
 
-@withPage(link:String) = {@link&format=page}
-
 @formats(ref:String) = {<td>
 				<code><a href="@ref=short">short</a></code>,
 				<code><a href="@ref=ids">ids</a></code>,
-				<code><a href="@ref=page">page</a></code>,
-				<code><a href="@ref=full">full</a></code> (default)
+				<code><a href="@ref=full">full</a></code>,
+				<code><a href="@ref=negotiate">negotiate</a></code> (default)
 		</td>}
 
 @sampleUsageCode(resourceType: String, resultType: String) = {
@@ -40,7 +38,6 @@
             <p>Type a @resourceType's name to get suggestions. Upon selecting a suggestion, the corresponding value will be inserted (here: @if(resultType=="short") {the completed term} else {the ID}). Search will return details on the selected @resourceType.</p>
             <form method="GET" class="form-inline" action="/@resourceType"> <!-- use full URL in your code, i.e. http://api.lobid.org/@resourceType -->
                 <input type="text" class="search-@resourceType" name="@queryType" id="id" style="width:300px"/>
-                <input type="hidden" name="format" value="page"/> <!-- to get JSON, omit the 'format' param -->
                 <button type="submit" class="btn">Search</button>
             </form>
             <p>This calls the <code>/@resourceType</code> endpoint with the <code>format=@resultType</code> parameter to get the suggestions. The actual search uses the <code>@queryType</code> parameter with the inserted value. See the implementation using JavaScript and jQuery UI on the right and the source of this page.</p>
@@ -59,8 +56,9 @@
 
 @main("Lobid API - Index") {
 		<h2>API endpoints and parameters</h2>
-		<p>Available endpoints and sample requests (all use GET; omit the <code>format=page</code> parameter for JSON-LD output; send an accept header for different RDF formats, see details below).</p>
-		<p>All endpoints support queries using the <code>id</code>, <code>name</code>, and <code>format</code> parameters:</p>
+		<p>Available endpoints and sample requests (all use GET).</p>
+		<p>All endpoints support queries using the <code>id</code>, <code>name</code>, and <code>format</code> parameters.</p>
+    <p>Result formats <code>short</code>, <code>ids</code>, and <code>full</code> return JSON; use <code>format=negotiate</code> (or none), and set an accept header for different RDF formats, see details below.</p>
 		<table class="table table-striped">
 		<tr>
 			<th style="width: 10%">Parameters &rarr; <br/>&darr; Endpoint</th>
@@ -73,12 +71,12 @@
 			<td><code>/resource</td>
 			@defining(("/resource?id=HT002189125", "/resource?id=0940450003", "/resource/HT002189125", "/resource/0940450003")){refs =>
 				<td>
-					<a href="@withPage(refs._1)">@refs._1</a> <br/>
-					<a href="@withPage(refs._2)">@refs._2</a> <br/>
-					<a href="@refs._3?format=page">@refs._3</a><br/>
-					<a href="@refs._4?format=page">@refs._4</a>
+					<a href="@refs._1">@refs._1</a> <br/>
+					<a href="@refs._2">@refs._2</a> <br/>
+					<a href="@refs._3">@refs._3</a><br/>
+					<a href="@refs._4">@refs._4</a>
 				</td>}
-			@defining("/resource?name=Faust"){ref => <td><a href="@withPage(ref)">@ref</a></td>}
+			@defining("/resource?name=Faust"){ref => <td><a href="@ref">@ref</a></td>}
 			@formats("/resource?name=Typee&format")
 			<td>Title data <br/> (lobid-resources)</td>
 		</tr>
@@ -86,10 +84,10 @@
 			<td><code>/item</td>
 			@defining(("/item?id=BT000000079%3AGA+644","/item/BT000000079%3AGA+644")){refs =>
 				<td>
-					<a href="@withPage(refs._1)">@refs._1</a> <br/>
-					<a href="@refs._2?format=page">@refs._2</a>
+					<a href="@refs._1">@refs._1</a> <br/>
+					<a href="@refs._2">@refs._2</a>
 				</td>}
-			@defining("/item?name=GA+644"){ref => <td><a href="@withPage(ref)">@ref</a></td>}
+			@defining("/item?name=GA+644"){ref => <td><a href="@ref">@ref</a></td>}
 			@formats("/item?name=GA+644&format")
 			<td>Inventory data <br/> (lobid-resources)</td>
 		</tr>
@@ -97,10 +95,10 @@
 			<td><code>/organisation</td>
 			@defining(("/organisation?id=DE-605","/organisation/DE-605")){refs =>
 				<td>
-					<a href="@withPage(refs._1)">@refs._1</a> <br/>
-					<a href="@refs._2?format=page">@refs._2</a>
+					<a href="@refs._1">@refs._1</a> <br/>
+					<a href="@refs._2">@refs._2</a>
 				</td> }
-			@defining("/organisation?name=Universität"){ref => <td><a href="@withPage(ref)">@ref</a></td>}
+			@defining("/organisation?name=Universität"){ref => <td><a href="@ref">@ref</a></td>}
 			@formats("/organisation?name=Universität&format")
 			<td>Authority data <br/> (lobid-organisations)</td>
 		</tr>
@@ -108,17 +106,17 @@
 			<td><code>/person</td>
 			@defining(("/person?id=118580604","/person/118580604")){refs =>
 				<td>
-					<a href="@withPage(refs._1)">@refs._1</a> <br/>
-					<a href="@refs._2?format=page">@refs._2</a>
+					<a href="@refs._1">@refs._1</a> <br/>
+					<a href="@refs._2">@refs._2</a>
 				</td>}
-			@defining("/person?name=Johann+Sebastian+Bach"){ref => <td><a href="@withPage(ref)">@ref</a></td>}
+			@defining("/person?name=Johann+Sebastian+Bach"){ref => <td><a href="@ref">@ref</a></td>}
 			@formats("/person?name=Johann+Sebastian+Bach&format")
 			<td>Authority data <br/> (GND)</td>
 		</tr>
 		<tr>
 			<td><code>/search</td>
-			@defining("/search?id=HT002189125"){ref => <td><a href="@ref">@ref</a></td>}
-			@defining("/search?name=Basel"){ref => <td><a href="@ref">@ref</a></td>}
+			@defining("/search?id=HT002189125&format=full"){ref => <td><a href="@ref">@ref</a></td>}
+			@defining("/search?name=Basel&format=full"){ref => <td><a href="@ref">@ref</a></td>}
 			@defining("/search?name=Basel&format"){ ref => <td>
 				<code><a href="@ref=short">short</a></code>,
 				<code><a href="@ref=ids">ids</a></code>,
@@ -139,9 +137,9 @@
 		</tr>
 		<tr>
 			<td><code>/resource</td>
-			<td>@defining(("/resource?author=118580604","/resource?author=Abramson")){ refs => <a href="@withPage(refs._1)">@refs._1</a><br/><a href="@withPage(refs._2)">@refs._2</a>}</td>
-			<td>@defining("/resource?subject=4414195-6"){ref => <a href="@withPage(ref)">@ref</a>}</td>
-			<td>@defining("/resource?set=NWBib"){ref => <a href="@withPage(ref)">@ref</a>}</td>
+			<td>@defining(("/resource?author=118580604","/resource?author=Abramson")){ refs => <a href="@refs._1">@refs._1</a><br/><a href="@refs._2">@refs._2</a>}</td>
+			<td>@defining("/resource?subject=4414195-6"){ref => <a href="@ref">@ref</a>}</td>
+			<td>@defining("/resource?set=NWBib"){ref => <a href="@ref">@ref</a>}</td>
 			<td>Title data <br/> (lobid-resources)</td>
 		</tr>
 	</table>

--- a/lodmill-ui/conf/routes
+++ b/lodmill-ui/conf/routes
@@ -9,14 +9,14 @@ GET     /                           controllers.Application.index()
 GET     /assets/*file               controllers.Assets.at(path="/public", file)
 
 # Individual, specialized endpoints for different resource types
-GET     /resource                   controllers.Api.resource(id: String ?= "", name: String ?= "", author: String ?= "", subject: String ?= "", set: String ?= "", format: String ?= "full", from: Int ?= 0, size: Int ?= 50)
-GET     /resource/:id               controllers.Api.resource(id: String, name: String ?= "", author: String ?= "", subject: String ?= "", set: String ?= "", format: String ?= "full", from: Int ?= 0, size: Int ?= 50)
-GET     /item                       controllers.Api.item(id: String ?= "", name: String ?= "", format: String ?= "full", from: Int ?= 0, size: Int ?= 50)
-GET     /item/:id                   controllers.Api.item(id: String, name: String ?= "", format: String ?= "full", from: Int ?= 0, size: Int ?= 50)
-GET     /organisation               controllers.Api.organisation(id: String ?= "", name: String ?= "", format: String ?= "full", from: Int ?= 0, size: Int ?= 50)
-GET     /organisation/:id           controllers.Api.organisation(id: String, name: String ?= "", format: String ?= "full", from: Int ?= 0, size: Int ?= 50)
-GET     /person                     controllers.Api.person(id: String ?= "", name: String ?= "", format: String ?= "full", from: Int ?= 0, size: Int ?= 50)
-GET     /person/:id                 controllers.Api.person(id: String, name: String ?= "", format: String ?= "full", from: Int ?= 0, size: Int ?= 50)
+GET     /resource                   controllers.Api.resource(id: String ?= "", name: String ?= "", author: String ?= "", subject: String ?= "", set: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /resource/:id               controllers.Api.resource(id: String, name: String ?= "", author: String ?= "", subject: String ?= "", set: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /item                       controllers.Api.item(id: String ?= "", name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /item/:id                   controllers.Api.item(id: String, name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /organisation               controllers.Api.organisation(id: String ?= "", name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /organisation/:id           controllers.Api.organisation(id: String, name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /person                     controllers.Api.person(id: String ?= "", name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /person/:id                 controllers.Api.person(id: String, name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
 
 # General search endpoint for searching over all resource types
-GET     /search                     controllers.Api.search(id: String ?= "", name: String ?= "", format: String ?= "full", from: Int ?= 0, size: Int ?= 50)
+GET     /search                     controllers.Api.search(id: String ?= "", name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)

--- a/lodmill-ui/test/tests/BrowserTests.java
+++ b/lodmill-ui/test/tests/BrowserTests.java
@@ -65,9 +65,9 @@ public class BrowserTests {
 						"http://d-nb.info/gnd/118836617");
 				browser.find("button", withText("Search")).first().click();
 				assertThat(browser.url()).isNotEqualTo(INDEX);
-				assertThat(browser.title()).isEqualTo("Lobid API - Documents");
-				assertThat(browser.pageSource()).contains("Schmidt, Hannelore")
-						.contains("Glaser, Hannelore").contains("Schmidt, Loki");
+				assertThat(browser.pageSource()).contains("118836617")
+						.contains("Schmidt, Hannelore").contains("Glaser, Hannelore")
+						.contains("Schmidt, Loki");
 			}
 		});
 	}
@@ -92,7 +92,7 @@ public class BrowserTests {
 				.contains("http://openlibrary.org/works/OL14953734W")
 				.contains("http://dbpedia.org/resource/Typee")
 				.contains("http://lobid.org/item/HT002189125%3AU+MEL-11")
-				.contains("Exemplar");
+				.contains("exemplar");
 	}
 
 	@Test


### PR DESCRIPTION
- Improve content negotiation to consider order of accepted content
- Remove `page` format, introduce `negotiate` format (new default)
- Update tests and sample queries on index page

This retains JSON as the default if any content is acceptable (_/_)
but will deliver HTML/RDFa if any content is acceptable, but e.g.
text/html is preferred (as typically requested by browsers).

Deployed for testing to http://staging.api.lobid.org/
