### PR TITLE
Redirect from path-style routes to `about` routes (see #157)

### DIFF
--- a/lodmill-ui/app/controllers/Path.java
+++ b/lodmill-ui/app/controllers/Path.java
@@ -1,0 +1,83 @@
+/* Copyright 2013 Fabian Steeg, hbz. Licensed under the Eclipse Public License 1.0 */
+
+package controllers;
+
+import play.mvc.Controller;
+import play.mvc.Result;
+
+/**
+ * Path controller. Implements path-style routes and `about` redirects.
+ * 
+ * @author Fabian Steeg (fsteeg)
+ */
+public final class Path extends Controller {
+
+	private Path() {
+		/* No instantiation */
+	}
+
+	/**
+	 * Redirect to
+	 * {@link #resourceAbout(String, String, String, String, String, String, int, int)}
+	 */
+	@SuppressWarnings("javadoc")
+	public static Result resource(final String id, final String name,
+			final String author, final String subject, final String set,
+			final String format, final int from, final int size) {
+		return redirect(routes.Path.resourceAbout(id, name, author, subject, set,
+				format, from, size));
+	}
+
+	/**
+	 * Return
+	 * {@link Api#resource(String, String, String, String, String, String, int, int)}
+	 */
+	@SuppressWarnings("javadoc")
+	public static Result resourceAbout(final String id, final String name,
+			final String author, final String subject, final String set,
+			final String format, final int from, final int size) {
+		return Api.resource(id, name, author, subject, set, format, from, size);
+	}
+
+	/** Redirect to {@link #itemAbout(String, String, String, int, int)} */
+	@SuppressWarnings("javadoc")
+	public static Result item(final String id, final String name,
+			final String format, final int from, final int size) {
+		return redirect(routes.Path.itemAbout(id, name, format, from, size));
+	}
+
+	/** Return {@link Api#item(String, String, String, int, int)} */
+	@SuppressWarnings("javadoc")
+	public static Result itemAbout(final String id, final String name,
+			final String format, final int from, final int size) {
+		return Api.item(id, name, format, from, size);
+	}
+
+	/** Redirect to {@link #organisationAbout(String, String, String, int, int)} */
+	@SuppressWarnings("javadoc")
+	public static Result organisation(final String id, final String name,
+			final String format, final int from, final int size) {
+		return redirect(routes.Path.organisationAbout(id, name, format, from, size));
+	}
+
+	/** Return {@link Api#organisation(String, String, String, int, int)} */
+	@SuppressWarnings("javadoc")
+	public static Result organisationAbout(final String id, final String name,
+			final String format, final int from, final int size) {
+		return Api.organisation(id, name, format, from, size);
+	}
+
+	/** Redirect to {@link #personAbout(String, String, String, int, int)} */
+	@SuppressWarnings("javadoc")
+	public static Result person(final String id, final String name,
+			final String format, final int from, final int size) {
+		return redirect(routes.Path.personAbout(id, name, format, from, size));
+	}
+
+	/** Return {@link Api#person(String, String, String, int, int)} */
+	@SuppressWarnings("javadoc")
+	public static Result personAbout(final String id, final String name,
+			final String format, final int from, final int size) {
+		return Api.person(id, name, format, from, size);
+	}
+}

--- a/lodmill-ui/app/views/index.scala.html
+++ b/lodmill-ui/app/views/index.scala.html
@@ -149,7 +149,7 @@
 
 	<h2>Content Negotiation</h2>
 	<p>To return different RDF serializations as the result format (default is JSON-LD), you can specify an accept header, e.g. for N-Triples:</p>
-	<pre>curl --header "Accept: text/plain" http://api.lobid.org/resource/HT002189125</pre>
+	<pre>curl -L --header "Accept: text/plain" http://api.lobid.org/resource/HT002189125</pre>
 	<p>Currently supported: @Serialization.values().map((s:Serialization) => s.name + " " + s.getTypes).mkString(", ")</p>
 
   <h2>Sample usage: auto suggest</h2>

--- a/lodmill-ui/conf/routes
+++ b/lodmill-ui/conf/routes
@@ -8,15 +8,21 @@ GET     /                           controllers.Application.index()
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)
 
-# Individual, specialized endpoints for different resource types
+# Individual, specialized API routes for different resource types
 GET     /resource                   controllers.Api.resource(id: String ?= "", name: String ?= "", author: String ?= "", subject: String ?= "", set: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
-GET     /resource/:id               controllers.Api.resource(id: String, name: String ?= "", author: String ?= "", subject: String ?= "", set: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
 GET     /item                       controllers.Api.item(id: String ?= "", name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
-GET     /item/:id                   controllers.Api.item(id: String, name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
 GET     /organisation               controllers.Api.organisation(id: String ?= "", name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
-GET     /organisation/:id           controllers.Api.organisation(id: String, name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
 GET     /person                     controllers.Api.person(id: String ?= "", name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
-GET     /person/:id                 controllers.Api.person(id: String, name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+
+# Path-style routes and `about` redirects
+GET     /resource/:id               controllers.Path.resource(id: String, name: String ?= "", author: String ?= "", subject: String ?= "", set: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /resource/:id/about         controllers.Path.resourceAbout(id: String, name: String ?= "", author: String ?= "", subject: String ?= "", set: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /item/:id                   controllers.Path.item(id: String, name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /item/:id/about             controllers.Path.itemAbout(id: String, name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /organisation/:id           controllers.Path.organisation(id: String, name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /organisation/:id/about     controllers.Path.organisationAbout(id: String, name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /person/:id                 controllers.Path.person(id: String, name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
+GET     /person/:id/about           controllers.Path.personAbout(id: String, name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)
 
 # General search endpoint for searching over all resource types
 GET     /search                     controllers.Api.search(id: String ?= "", name: String ?= "", format: String ?= "negotiate", from: Int ?= 0, size: Int ?= 50)


### PR DESCRIPTION
Closes #157

Deployed to staging for testing.

Sample: http://staging.api.lobid.org/resource/HT002189125
