### PR TITLE
Remove documentation on path-style queries for non-hbz IDs

### DIFF
--- a/lodmill-ui/app/views/index.scala.html
+++ b/lodmill-ui/app/views/index.scala.html
@@ -71,10 +71,8 @@
 			<td><code>/resource</td>
 			@defining(("/resource?id=HT002189125", "/resource?id=0940450003", "/resource?id=urn:nbn:de:101:1-201210094953", "/resource/HT002189125", "/resource/0940450003", "/resource/urn%3Anbn%3Ade%3A101%3A1-201210094953")){refs =>
 				<td>
-					as parameter, by <br/>
-					<a href="@refs._1">resource ID</a>, <a href="@refs._2">ISBN</a>, <a href="@refs._3">URN</a> <br/>
-					as path element, by <br/>
-					<a href="@refs._4">resource ID</a>, <a href="@refs._5">ISBN</a>, <a href="@refs._6">URN</a>
+					<a href="@refs._1">hbz ID</a>, <a href="@refs._2">ISBN</a>, or <a href="@refs._3">URN</a> as parameter<br/>
+					<a href="@refs._4">hbz ID</a> as path segment
 				</td>}
 			@defining("/resource?name=Faust"){ref => <td><a href="@ref">@ref</a></td>}
 			@formats("/resource?name=Typee&format")

--- a/lodmill-ui/test/tests/BrowserTests.java
+++ b/lodmill-ui/test/tests/BrowserTests.java
@@ -78,7 +78,7 @@ public class BrowserTests {
 			@Override
 			public void invoke(final TestBrowser browser) {
 				browser.goTo(INDEX);
-				browser.find("a", withText("resource ID")).first().click();
+				browser.find("a", withText("hbz ID")).first().click();
 				assertTypee(browser);
 			}
 		});


### PR DESCRIPTION
Path-style queries redirect to `about` pages, which makes no sense
for non URI-fied IDs in general (and ISBNs in particular).

See #160 for details.

Deployed to staging for testing, see documentation on http://staging.api.lobid.org/
