### PR TITLE
Handle blank nodes with identical labels from different files

### DIFF
--- a/lodmill-ld/src/main/java/org/lobid/lodmill/hadoop/NTriplesToJsonLd.java
+++ b/lodmill-ld/src/main/java/org/lobid/lodmill/hadoop/NTriplesToJsonLd.java
@@ -162,8 +162,8 @@ public class NTriplesToJsonLd implements Tool {
 				final Context context, final String val, final Triple triple)
 				throws IOException, InterruptedException {
 			final String subject =
-					triple.getSubject().isBlank() ? val.substring(val.indexOf("_:"),
-							val.indexOf(" ")).trim() : triple.getSubject().toString();
+					triple.getSubject().isBlank() ? CollectSubjects.blankSubjectLabel(
+							val, context.getInputSplit()) : triple.getSubject().toString();
 			if (subjectIsUriToBeCollected(triple)
 					&& !objectIsUnresolvedBlankNode(triple))
 				context.write(new Text(wrapped(subject.trim())), value);

--- a/lodmill-ld/src/test/java/org/lobid/lodmill/hadoop/IntegrationTestCollectSubjects.java
+++ b/lodmill-ld/src/test/java/org/lobid/lodmill/hadoop/IntegrationTestCollectSubjects.java
@@ -30,9 +30,12 @@ import org.slf4j.LoggerFactory;
  */
 @SuppressWarnings("javadoc")
 public class IntegrationTestCollectSubjects extends ClusterMapReduceTestCase {
-	private static final String TEST_FILE =
-			"src/test/resources/lobid-org-with-blank-nodes.nt";
-	private static final String HDFS_IN = "blank-nodes-test/sample.nt";
+	private static final String TEST_FILE_1 =
+			"src/test/resources/lobid-org-with-blank-nodes-1.nt";
+	private static final String TEST_FILE_2 =
+			"src/test/resources/lobid-org-with-blank-nodes-2.nt";
+	private static final String HDFS_IN_1 = "blank-nodes-test/sample-1.nt";
+	private static final String HDFS_IN_2 = "blank-nodes-test/sample-2.nt";
 	private static final String HDFS_OUT = "out/sample";
 	private FileSystem hdfs = null;
 
@@ -42,7 +45,8 @@ public class IntegrationTestCollectSubjects extends ClusterMapReduceTestCase {
 		System.setProperty("hadoop.log.dir", "/tmp/logs");
 		super.setUp();
 		hdfs = getFileSystem();
-		hdfs.copyFromLocalFile(new Path(TEST_FILE), new Path(HDFS_IN));
+		hdfs.copyFromLocalFile(new Path(TEST_FILE_1), new Path(HDFS_IN_1));
+		hdfs.copyFromLocalFile(new Path(TEST_FILE_2), new Path(HDFS_IN_2));
 	}
 
 	@Test
@@ -53,11 +57,11 @@ public class IntegrationTestCollectSubjects extends ClusterMapReduceTestCase {
 		final String string = readResults().toString();
 		System.err.println("Collection output:\n" + string);
 		assertEquals(
-				"_:node16vicghfdx1 http://lobid.org/organisation/ACRPP,http://lobid.org/organisation/AAAAA\n"
-						+ "_:node16vicghfdx2 http://lobid.org/organisation/ACRPP\n"
+				" http://lobid.org/organisation/ACRPP,http://lobid.org/organisation/AAAAA\n"
+						+ " http://lobid.org/organisation/ACRPP\n"
 						+ "http://purl.org/lobid/fundertype#n08 http://lobid.org/organisation/ACRPP\n"
 						+ "http://purl.org/lobid/stocksize#n06 http://lobid.org/organisation/ACRPP\n",
-				string);
+				string.replaceAll("_:[^\\s]+", ""));
 		writeZippedMapFile();
 	}
 
@@ -79,7 +83,7 @@ public class IntegrationTestCollectSubjects extends ClusterMapReduceTestCase {
 		conf.setStrings(CollectSubjects.PREFIX_KEY, "http://lobid.org/organisation");
 		final Job job = new Job(conf);
 		job.setJobName("CollectSubjects");
-		FileInputFormat.addInputPaths(job, HDFS_IN);
+		FileInputFormat.addInputPaths(job, HDFS_IN_1 + "," + HDFS_IN_2);
 		FileOutputFormat.setOutputPath(job, new Path(HDFS_OUT));
 		job.setMapperClass(CollectSubjectsMapper.class);
 		job.setReducerClass(CollectSubjectsReducer.class);

--- a/lodmill-ld/src/test/java/org/lobid/lodmill/hadoop/IntegrationTestLobidNTriplesToJsonLd.java
+++ b/lodmill-ld/src/test/java/org/lobid/lodmill/hadoop/IntegrationTestLobidNTriplesToJsonLd.java
@@ -32,11 +32,16 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("javadoc")
 public class IntegrationTestLobidNTriplesToJsonLd extends
 		ClusterMapReduceTestCase {
-	private static final String TEST_FILE_TRIPLES =
-			"src/test/resources/lobid-org-with-blank-nodes.nt";
+	private static final String TEST_FILE_TRIPLES_1 =
+			"src/test/resources/lobid-org-with-blank-nodes-1.nt";
+	private static final String TEST_FILE_TRIPLES_2 =
+			"src/test/resources/lobid-org-with-blank-nodes-2.nt";
 	private static final String TEST_FILE_SUBJECTS =
 			"src/test/resources/lobid-org-required-subjects.out";
-	private static final String HDFS_IN_TRIPLES = "blank-nodes-test/sample.nt";
+	private static final String HDFS_IN_TRIPLES_1 =
+			"blank-nodes-test/sample-1.nt";
+	private static final String HDFS_IN_TRIPLES_2 =
+			"blank-nodes-test/sample-2.nt";
 	private static final String HDFS_IN_SUBJECTS = "blank-nodes-test/subjects";
 	private static final String HDFS_OUT = "out/sample";
 	private static final String HDFS_OUT_ZIP = "out/zip";
@@ -48,8 +53,10 @@ public class IntegrationTestLobidNTriplesToJsonLd extends
 		System.setProperty("hadoop.log.dir", "/tmp/logs");
 		super.setUp();
 		hdfs = getFileSystem();
-		hdfs.copyFromLocalFile(new Path(TEST_FILE_TRIPLES), new Path(
-				HDFS_IN_TRIPLES));
+		hdfs.copyFromLocalFile(new Path(TEST_FILE_TRIPLES_1), new Path(
+				HDFS_IN_TRIPLES_1));
+		hdfs.copyFromLocalFile(new Path(TEST_FILE_TRIPLES_2), new Path(
+				HDFS_IN_TRIPLES_2));
 		hdfs.copyFromLocalFile(new Path(TEST_FILE_SUBJECTS), new Path(
 				HDFS_IN_SUBJECTS));
 	}
@@ -93,7 +100,8 @@ public class IntegrationTestLobidNTriplesToJsonLd extends
 		DistributedCache.addCacheFile(zippedMapFile, conf);
 		final Job job = new Job(conf);
 		job.setJobName("IntegrationTestLobidNTriplesToJsonLd");
-		FileInputFormat.addInputPaths(job, HDFS_IN_TRIPLES);
+		FileInputFormat.addInputPaths(job, HDFS_IN_TRIPLES_1 + ","
+				+ HDFS_IN_TRIPLES_2);
 		FileOutputFormat.setOutputPath(job, new Path(HDFS_OUT));
 		job.setMapperClass(NTriplesToJsonLdMapper.class);
 		job.setReducerClass(NTriplesToJsonLdReducer.class);

--- a/lodmill-ld/src/test/java/org/lobid/lodmill/hadoop/UnitTestCollectSubjects.java
+++ b/lodmill-ld/src/test/java/org/lobid/lodmill/hadoop/UnitTestCollectSubjects.java
@@ -123,7 +123,8 @@ public final class UnitTestCollectSubjects {
 	@Test
 	public void testMapperBlanksGeo() throws IOException {
 		final List<Pair<Text, Text>> result = runGeoMapDriver();
-		assertEquals(new Text("_:node16vicghfdx21"), result.get(0).getFirst());
+		assertEquals(new Text("_:node16vicghfdx21:somefile"), result.get(0)
+				.getFirst());
 		assertEquals(new Text("http://lobid.org/organisation/AF-KaIS"),
 				result.get(0).getSecond());
 	}
@@ -138,7 +139,7 @@ public final class UnitTestCollectSubjects {
 	@Test
 	public void testReducerBlanksGeo() throws IOException {// NOPMD (MRUnit)
 		setUpReduceInput(runGeoMapDriver());
-		reduceDriver.addOutput(new Text("_:node16vicghfdx21"), new Text(
+		reduceDriver.addOutput(new Text("_:node16vicghfdx21:somefile"), new Text(
 				"http://lobid.org/organisation/AF-KaIS,"
 						+ "http://lobid.org/organisation/AE-ShAU"));
 		reduceDriver.runTest(false);
@@ -163,7 +164,8 @@ public final class UnitTestCollectSubjects {
 	@Test
 	public void testMapperBlanksAddress() throws IOException {
 		final List<Pair<Text, Text>> result = runAddressMapDriver();
-		assertEquals(new Text("_:node16vicghfdx20"), result.get(0).getFirst());
+		assertEquals(new Text("_:node16vicghfdx20:somefile"), result.get(0)
+				.getFirst());
 		assertEquals(new Text("http://lobid.org/organisation/AE-ShAU"),
 				result.get(0).getSecond());
 	}
@@ -178,7 +180,7 @@ public final class UnitTestCollectSubjects {
 	@Test
 	public void testReducerBlanksAddress() throws IOException { // NOPMD (MRUnit)
 		setUpReduceInput(runAddressMapDriver());
-		reduceDriver.addOutput(new Text("_:node16vicghfdx20"), new Text(
+		reduceDriver.addOutput(new Text("_:node16vicghfdx20:somefile"), new Text(
 				"http://lobid.org/organisation/AE-ShAU,"
 						+ "http://lobid.org/organisation/AF-KaIS"));
 		reduceDriver.runTest(false);

--- a/lodmill-ld/src/test/resources/lobid-org-required-subjects.out
+++ b/lodmill-ld/src/test/resources/lobid-org-required-subjects.out
@@ -1,4 +1,4 @@
-_:node16vicghfdx1 http://lobid.org/organisation/ACRPP,http://lobid.org/organisation/AAAAA
-_:node16vicghfdx2 http://lobid.org/organisation/ACRPP
+_:b1:blank-nodes-test/sample-1.nt http://lobid.org/organisation/ACRPP,http://lobid.org/organisation/AAAAA
+_:b1:blank-nodes-test/sample-2.nt http://lobid.org/organisation/ACRPP
 http://purl.org/lobid/fundertype#n08 http://lobid.org/organisation/ACRPP
 http://purl.org/lobid/stocksize#n06 http://lobid.org/organisation/ACRPP

--- a/lodmill-ld/src/test/resources/lobid-org-with-blank-nodes-1.nt
+++ b/lodmill-ld/src/test/resources/lobid-org-with-blank-nodes-1.nt
@@ -1,0 +1,10 @@
+<http://lobid.org/organisation/ACRPP> <http://purl.org/dc/terms/identifier> invalid .
+<http://lobid.org/organisation/ACRPP> <http://purl.org/dc/terms/identifier> "ACRPP" .
+<http://lobid.org/organisation/ACRPP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Organization> .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> .
+_:b1 <http://www.w3.org/2003/01/geo/wgs84_pos#lat> "48.8681710" .
+_:b1 <http://www.w3.org/2003/01/geo/wgs84_pos#long> "2.3377220" .
+<http://lobid.org/organisation/ACRPP> <http://d-nb.info/standards/elementset/gnd#preferredNameEntityForThePerson> _:b0 .
+<http://lobid.org/organisation/ACRPP> <http://www.w3.org/2003/01/geo/wgs84_pos#location> _:b1 .
+<http://lobid.org/organisation/AAAAA> <http://www.w3.org/2003/01/geo/wgs84_pos#location> _:b1 .
+<http://lobid.org/organisation/ACRPP> <http://www.w3.org/2004/02/skos/core#prefLabel> "Association pour la conservation et la r\u00E9production photographique de la presse" .

--- a/lodmill-ld/src/test/resources/lobid-org-with-blank-nodes-2.nt
+++ b/lodmill-ld/src/test/resources/lobid-org-with-blank-nodes-2.nt
@@ -1,0 +1,20 @@
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2006/vcard/ns#Work> .
+_:b1 <http://www.w3.org/2006/vcard/ns#country-name> "France" .
+_:b1 <http://www.w3.org/2006/vcard/ns#locality> "Paris" .
+_:b1 <http://www.w3.org/2006/vcard/ns#postal-code> "75002" .
+_:b1 <http://www.w3.org/2006/vcard/ns#street-address> "Rue de Louvois 4" .
+<http://lobid.org/organisation/ACRPP> <http://www.w3.org/2006/vcard/ns#adr> _:b1 .
+<http://lobid.org/organisation/ACRPP> <http://xmlns.com/foaf/0.1/name> "Association pour la conservation et la r\u00E9production photographique de la presse" .
+<http://lobid.org/organisation/ACRPP> <http://lobid.org/vocab/lobid#contactqr> <http://lobid.org/media/ACRPP_contactqr.png> .
+<http://lobid.org/organisation/ACRPP> <http://purl.org/lobid/lv#fundertype> <http://purl.org/lobid/fundertype#n08> .
+<http://purl.org/lobid/fundertype#n08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<http://purl.org/lobid/fundertype#n08> <http://www.w3.org/2004/02/skos/core#inScheme> <http://purl.org/lobid/fundertype#scheme> .
+<http://purl.org/lobid/fundertype#n08> <http://www.w3.org/2004/02/skos/core#notation> "08"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://purl.org/lobid/fundertype#n08> <http://www.w3.org/2004/02/skos/core#prefLabel> "Corporate Body or Foundation under Private Law"@en .
+<http://purl.org/lobid/fundertype#n08> <http://www.w3.org/2004/02/skos/core#prefLabel> "K\u00F6rperschaft oder Stiftung des privaten Rechts"@de .
+<http://lobid.org/organisation/ACRPP> <http://purl.org/lobid/lv#stocksize> <http://purl.org/lobid/stocksize#n06> .
+<http://purl.org/lobid/stocksize#n06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<http://purl.org/lobid/stocksize#n06> <http://www.w3.org/2004/02/skos/core#inScheme> <http://purl.org/lobid/stocksize#scheme> .
+<http://purl.org/lobid/stocksize#n06> <http://www.w3.org/2004/02/skos/core#notation> "06"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://purl.org/lobid/stocksize#n06> <http://www.w3.org/2004/02/skos/core#prefLabel> "10,001 - 30,000"@en .
+<http://purl.org/lobid/stocksize#n06> <http://www.w3.org/2004/02/skos/core#prefLabel> "10.001 - 30.000"@de .


### PR DESCRIPTION
Since blank nodes from different files may have identical labels, we add the file path to the node identifier used to track blank nodes for which we want to resolve details (see #109).

Tested by reindexing `/organisations` on http://staging.api.lobid.org

<!---
@huboard:{"order":18.25}
-->
