### PR TITLE
Use `Operator.OR` for organisations-by-name queries

### DIFF
--- a/lodmill-ui/app/models/queries/LobidOrganisations.java
+++ b/lodmill-ui/app/models/queries/LobidOrganisations.java
@@ -50,7 +50,7 @@ public class LobidOrganisations {
 		@Override
 		public QueryBuilder build(final String queryString) {
 			return multiMatchQuery(queryString, fields().toArray(new String[] {}))
-					.operator(Operator.AND);
+					.operator(Operator.OR);
 		}
 
 	}

--- a/lodmill-ui/test/tests/SearchTests.java
+++ b/lodmill-ui/test/tests/SearchTests.java
@@ -118,11 +118,13 @@ public class SearchTests {
 
 	@Test
 	public void searchViaModelOrgName() {
-		final String term = "hbz Land";
-		final List<Document> docs =
-				Search.documents(term, Index.LOBID_ORGANISATIONS, Parameter.NAME, FROM,
-						SIZE);
-		assertThat(docs.size()).isEqualTo(1);
+		assertThat(searchOrgByName("hbz Land")).isEqualTo(2);
+		assertThat(searchOrgByName("hbz Schmeckermeck")).isEqualTo(1);
+	}
+
+	private static int searchOrgByName(final String term) {
+		return Search.documents(term, Index.LOBID_ORGANISATIONS, Parameter.NAME,
+				FROM, SIZE).size();
 	}
 
 	/*@formatter:off*/


### PR DESCRIPTION
See #184

Deployed to staging, e.g. http://staging.api.lobid.org/organisation?name=Bundesinstitut+f%C3%BCr+Arzneimittel+und+Medizinprodukte+%28BfArM%29%2C+Abteilung+%E2%80%9EForschung%E2%80%9C%2C+53175+Bonn

Also yields suggestions when pasting "Bundesinstitut für Arzneimittel und Medizinprodukte (BfArM), Abteilung „Forschung“, 53175 Bonn" into the organisations search box on http://staging.api.lobid.org

<!---
@huboard:{"order":18.5}
-->
