### PR TITLE
Rename subject rdf marker to be more self-explanatory

### DIFF
--- a/lodmill-rd/src/main/java/org/lobid/lodmill/AbstractGraphPipeEncoder.java
+++ b/lodmill-rd/src/main/java/org/lobid/lodmill/AbstractGraphPipeEncoder.java
@@ -22,7 +22,7 @@ import org.culturegraph.mf.framework.annotations.Out;
 public abstract class AbstractGraphPipeEncoder extends
 		DefaultStreamPipe<ObjectReceiver<String>> {
 
-	static final String SUBJECT_NAME = "subject";
+	static final String SUBJECT_NAME = "~rdf:subject";
 	String subject;
 
 	/**

--- a/lodmill-rd/src/main/resources/morphGeonamesCsv2ld.xml
+++ b/lodmill-rd/src/main/resources/morphGeonamesCsv2ld.xml
@@ -2,7 +2,7 @@
 <metamorph xmlns="http://www.culturegraph.org/metamorph" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	version="1">
 	<rules>
-		<data source="0" name="subject">
+		<data source="0" name="~rdf:subject">
 			<regexp match=".*" format="http://sws.geonames.org/${0}"/>
 		</data>
 		<data source="1" name="http://xmlns.com/foaf/0.1/name"/>

--- a/lodmill-rd/src/test/java/org/lobid/lodmill/TransformationZvdd-title-digital.xml
+++ b/lodmill-rd/src/test/java/org/lobid/lodmill/TransformationZvdd-title-digital.xml
@@ -46,7 +46,7 @@
 			<cgxml:cgxml version="1.0">
 				<cgxml:records>
 					<cgxml:record id="1">
-						<cgxml:literal name="subject" value="resource:D184000" />
+						<cgxml:literal name="~rdf:subject" value="resource:D184000" />
 						<cgxml:literal name="http://purl.org/dc/terms/isFormatOf"
 							value="resource:P184000" />
 						<cgxml:literal name="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"

--- a/lodmill-rd/src/test/java/org/lobid/lodmill/TransformationZvdd-title-print.xml
+++ b/lodmill-rd/src/test/java/org/lobid/lodmill/TransformationZvdd-title-print.xml
@@ -49,7 +49,7 @@
 			<cgxml:cgxml version="1.0">
 				<cgxml:records>
 					<cgxml:record id="1">
-						<cgxml:literal name="subject" value="resource:P184000" />
+						<cgxml:literal name="~rdf:subject" value="resource:P184000" />
 						<cgxml:literal name="http://purl.org/dc/terms/hasFormat"
 							value="resource:D184000" />
 						<cgxml:literal name="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"

--- a/lodmill-rd/src/test/resources/morph_zdb-isil-file-pica2ld.xml
+++ b/lodmill-rd/src/test/resources/morph_zdb-isil-file-pica2ld.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1">
 	<rules>
 		<!-- General attributes for each record: -->
-		<data source="008H.e" name="subject">
+		<data source="008H.e" name="~rdf:subject">
 			<regexp match="(.*)" format="http://lobid.org/organisation/${1}"/>
 		</data>
 		<data source="008H.e" name="http://purl.org/dc/terms/identifier">

--- a/lodmill-rd/src/test/resources/morph_zvdd-collection2ld.xml
+++ b/lodmill-rd/src/test/resources/morph_zvdd-collection2ld.xml
@@ -72,7 +72,7 @@
 				<regexp match="cooperation" format=""/>
 			</data>
 		</combine>
-		<data source="992  .a" name="subject">
+		<data source="992  .a" name="~rdf:subject">
 			<regexp match="(.*:.*\..*)" format="${1}"/><!-- some sanitizing -->
 		</data>
 		<data source="992  .a" name="http://purl.org/dc/elements/1.1/subject">

--- a/lodmill-rd/src/test/resources/morph_zvdd-title-digital2ld.xml
+++ b/lodmill-rd/src/test/resources/morph_zvdd-title-digital2ld.xml
@@ -3,7 +3,7 @@
 		version="1">
 		<rules>
 				<!-- General attributes for each record: -->
-				<data source="001." name="subject">
+				<data source="001." name="~rdf:subject">
 						<regexp match=".*" format="resource:D${0}"/>
 				</data>
 				<data source="001." name="http://purl.org/dc/terms/isFormatOf">

--- a/lodmill-rd/src/test/resources/morph_zvdd-title-print2ld.xml
+++ b/lodmill-rd/src/test/resources/morph_zvdd-title-print2ld.xml
@@ -3,7 +3,7 @@
 		version="1">
 		<rules>
 				<!-- General attributes for each record: -->
-				<data source="001." name="subject">
+				<data source="001." name="~rdf:subject">
 						<regexp match="(.*)" format="resource:P${1}"/>
 				</data>
 				<data source="001." name="http://purl.org/dc/terms/hasFormat">

--- a/lodmill-rd/transformations/zvdd/mapping/morph_zvdd-collection2ld.xml
+++ b/lodmill-rd/transformations/zvdd/mapping/morph_zvdd-collection2ld.xml
@@ -72,7 +72,7 @@
 				<regexp match="cooperation" format=""/>
 			</data>
 		</combine>
-		<data source="992  .a" name="subject">
+		<data source="992  .a" name="~rdf:subject">
 			<regexp match="(.*:.*\..*)" format="${1}"/><!-- some sanitizing -->
 		</data>
 		<data source="992  .a" name="http://purl.org/dc/elements/1.1/subject">

--- a/lodmill-rd/transformations/zvdd/mapping/morph_zvdd-title-digital2ld.xml
+++ b/lodmill-rd/transformations/zvdd/mapping/morph_zvdd-title-digital2ld.xml
@@ -3,7 +3,7 @@
 		version="1">
 		<rules>
 				<!-- General attributes for each record: -->
-				<data source="001." name="subject">
+				<data source="001." name="~rdf:subject">
 						<regexp match=".*" format="resource:D${0}"/>
 				</data>
 				<data source="001." name="http://purl.org/dc/terms/isFormatOf">

--- a/lodmill-rd/transformations/zvdd/mapping/morph_zvdd-title-print2ld.xml
+++ b/lodmill-rd/transformations/zvdd/mapping/morph_zvdd-title-print2ld.xml
@@ -3,7 +3,7 @@
 		version="1">
 		<rules>
 				<!-- General attributes for each record: -->
-				<data source="001." name="subject">
+				<data source="001." name="~rdf:subject">
 						<regexp match="(.*)" format="resource:P${1}"/>
 				</data>
 				<data source="001." name="http://purl.org/dc/terms/hasFormat">


### PR DESCRIPTION
This renaming makes our morph files more like those of metafacture-core, which uses "~rdf:about" for similar reasons,  see e.g. https://github.com/culturegraph/metafacture-core/blob/42bb838cac10798a5f408eda5a5061b150bdd446/examples/marc21-to-edm/MARC21-EDM.xml 
