### PR TITLE
Use jsonld-java 0.3-SNAPSHOT to support RDF-XML output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
 jdk: oraclejdk7
 before_install:
   - cd lodmill-rd; sh install-dependencies.sh; cd ..
+  - cd lodmill-ld; sh install-dependencies.sh; cd ..
 install:
   - mvn clean install -e -q -DskipTests=true --settings settings.xml
 before_script:

--- a/lodmill-ld/install-dependencies.sh
+++ b/lodmill-ld/install-dependencies.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+cd ../..
+git clone https://github.com/jsonld-java/jsonld-java.git jsonld-java-dependency
+cd jsonld-java-dependency
+git checkout 104d5b92cbbbfbb7d0e5d450ae669cb71f14adba
+mvn clean install -DskipTests=true

--- a/lodmill-ld/pom.xml
+++ b/lodmill-ld/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.lobid</groupId>
 	<artifactId>lodmill-ld</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.1-SNAPSHOT</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -151,13 +151,13 @@
 		<dependency>
 			<groupId>com.github.jsonld-java</groupId>
 			<artifactId>jsonld-java</artifactId>
-			<version>0.2</version>
+			<version>0.3-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.github.jsonld-java</groupId>
 			<artifactId>jsonld-java-jena</artifactId>
-			<version>0.2</version>
+			<version>0.3-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/lodmill-ld/src/main/java/org/lobid/lodmill/JsonLdConverter.java
+++ b/lodmill-ld/src/main/java/org/lobid/lodmill/JsonLdConverter.java
@@ -2,6 +2,7 @@
 
 package org.lobid.lodmill;
 
+import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 
@@ -11,8 +12,6 @@ import org.json.simple.JSONValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.github.jsonldjava.core.JSONLD;
 import com.github.jsonldjava.core.JSONLDProcessingError;
 import com.github.jsonldjava.core.Options;
@@ -73,7 +72,7 @@ public class JsonLdConverter {
 			final StringWriter writer = new StringWriter();
 			model.write(writer, format.getName());
 			return writer.toString();
-		} catch (JsonParseException | JsonMappingException | JSONLDProcessingError e) {
+		} catch (JSONLDProcessingError | IOException e) {
 			LOG.error(e.getMessage(), e);
 		}
 		return null;

--- a/lodmill-ui/app/controllers/Serialization.java
+++ b/lodmill-ui/app/controllers/Serialization.java
@@ -17,6 +17,7 @@ import org.lobid.lodmill.JsonLdConverter;
 public enum Serialization {/* @formatter:off */
 		JSON_LD(null, Arrays.asList("application/json", "application/ld+json")),
 		RDF_A(null, Arrays.asList("text/html", "text/xml", "application/xml")),
+		RDF_XML(JsonLdConverter.Format.RDF_XML, Arrays.asList("application/rdf+xml")),
 		N_TRIPLE(JsonLdConverter.Format.N_TRIPLE, Arrays.asList("text/plain")),
 		N3(JsonLdConverter.Format.N3, Arrays.asList("text/rdf+n3", "text/n3")),
 		TURTLE(JsonLdConverter.Format.TURTLE, /* @formatter:on */

--- a/lodmill-ui/app/models/Document.java
+++ b/lodmill-ui/app/models/Document.java
@@ -2,6 +2,7 @@
 
 package models;
 
+import java.io.IOException;
 import java.util.HashMap;
 
 import org.json.simple.JSONValue;
@@ -10,8 +11,6 @@ import org.lobid.lodmill.JsonLdConverter.Format;
 
 import play.Logger;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.github.jsonldjava.core.JSONLD;
 import com.github.jsonldjava.core.JSONLDProcessingError;
 import com.github.jsonldjava.utils.JSONUtils;
@@ -40,7 +39,7 @@ public class Document {
 					JSONLD.compact(JSONUtils.fromString(source),
 							new HashMap<String, Object>());
 			return JSONUtils.toString(compactJsonLd);
-		} catch (JsonParseException | JsonMappingException | JSONLDProcessingError e) {
+		} catch (JSONLDProcessingError | IOException e) {
 			e.printStackTrace();
 			return null;
 		}

--- a/lodmill-ui/project/Build.scala
+++ b/lodmill-ui/project/Build.scala
@@ -10,7 +10,7 @@ object ApplicationBuild extends Build {
     val appDependencies = Seq(
       javaCore,
       "org.elasticsearch" % "elasticsearch" % "0.90.5" withSources(),
-      "org.lobid" % "lodmill-ld" % "0.2.0-SNAPSHOT",
+      "org.lobid" % "lodmill-ld" % "0.2.1-SNAPSHOT",
       "org.scalatest" %% "scalatest" % "1.9.1" % "test"
     )
 

--- a/lodmill-ui/test/tests/SearchTests.java
+++ b/lodmill-ui/test/tests/SearchTests.java
@@ -418,6 +418,17 @@ public class SearchTests {
 	}
 
 	@Test
+	public void searchViaApiWithContentNegotiationRdfXml() {
+		running(TEST_SERVER, new Runnable() {
+			@Override
+			public void run() {
+				assertThat(call(ENDPOINT, "application/rdf+xml")).isNotEmpty()
+						.contains("<rdf:RDF");
+			}
+		});
+	}
+
+	@Test
 	public void searchViaApiWithContentNegotiationN3() {
 		running(TEST_SERVER, new Runnable() {
 			@Override


### PR DESCRIPTION
See #217.

Deployed to staging, sample usage:

`curl -L --header "Accept: application/rdf+xml" http://staging.api.lobid.org/organisation/DE-605`

<!---
@huboard:{"order":11.625}
-->
