### PR TITLE
Add missing `@context` object to GND context document

### DIFF
--- a/lodmill-ui/public/contexts/gnd.json
+++ b/lodmill-ui/public/contexts/gnd.json
@@ -1,4 +1,6 @@
 {
+  "@context":
+  {
     "academicDegree": {
         "@id": "http://d-nb.info/standards/elementset/gnd#academicDegree",
         "@type": "@id"
@@ -707,4 +709,5 @@
         "@id": "http://d-nb.info/standards/elementset/gnd#writerOfAddedCommentary",
         "@type": "@id"
     }
+  }
 }


### PR DESCRIPTION
See #292.

Deployed to staging, see http://staging.api.lobid.org/context/gnd.json

<!---
@huboard:{"order":145.0}
-->
