### PR TITLE
Pass alias suffix to index script, optionally skip aliasing

### DIFF
--- a/lodmill-ld/doc/scripts/convert.sh
+++ b/lodmill-ld/doc/scripts/convert.sh
@@ -7,7 +7,7 @@ then
 fi
 
 export HADOOP=/opt/hadoop/hadoop
-export HADOOP_CLASSPATH=../../target/lodmill-ld-1.1.0-jar-with-dependencies.jar
+export HADOOP_CLASSPATH=../../target/lodmill-ld-1.1.1-jar-with-dependencies.jar
 
 TMP=output/json-ld-tmp
 

--- a/lodmill-ld/doc/scripts/index.sh
+++ b/lodmill-ld/doc/scripts/index.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-if [ $# -ne 3 ]
+if [ $# -ne 4 ]
 then
-  echo "Usage: `basename $0` INPUT ES_SERVER ES_CLUSTER"
+  echo "Usage: `basename $0` INPUT ES_SERVER ES_CLUSTER INDEX_ALIAS"
   exit 65
 fi
 
@@ -11,5 +11,6 @@ export HADOOP=/opt/hadoop/hadoop
 INPUT=$1
 ES_SERVER=$2
 ES_CLUSTER=$3
+INDEX_ALIAS=$4
 
-$HADOOP/bin/hadoop jar ../../target/lodmill-ld-1.1.0-jar-with-dependencies.jar org.lobid.lodmill.hadoop.IndexFromHdfsInElasticSearch hdfs://10.9.0.10:8020/ $INPUT $ES_SERVER $ES_CLUSTER
+$HADOOP/bin/hadoop jar ../../target/lodmill-ld-1.1.1-jar-with-dependencies.jar org.lobid.lodmill.hadoop.IndexFromHdfsInElasticSearch hdfs://10.9.0.10:8020/ $INPUT $ES_SERVER $ES_CLUSTER $INDEX_ALIAS

--- a/lodmill-ld/doc/scripts/process.sh
+++ b/lodmill-ld/doc/scripts/process.sh
@@ -12,17 +12,17 @@ ES_CLUSTER=$2
 TIME=`date '+%Y%m%d-%H%M%S'`
 
 ORGANISATIONS=output/json-ld-lobid-organisations
-sh convert.sh hbzlod/lobid-organisations/ $ORGANISATIONS http://lobid.org/organisation lobid-orgs-index-$TIME json-ld-lobid-orgs
-sh index.sh $ORGANISATIONS $ES_SERVER $ES_CLUSTER
+sh convert.sh hbzlod/lobid-organisations/ $ORGANISATIONS http://lobid.org/organisation lobid-organisations-$TIME json-ld-lobid-orgs
+sh index.sh $ORGANISATIONS $ES_SERVER $ES_CLUSTER ""
 
 GND=output/json-ld-gnd
-sh convert.sh extlod/gnd/ $GND http://d-nb.info/gnd gnd-index-$TIME json-ld-gnd
-sh index.sh $GND $ES_SERVER $ES_CLUSTER
+sh convert.sh extlod/gnd/ $GND http://d-nb.info/gnd gnd-$TIME json-ld-gnd
+sh index.sh $GND $ES_SERVER $ES_CLUSTER ""
 
 RESOURCES=output/json-ld-lobid-resources
-sh convert.sh hbzlod/lobid-resources/,hbzlod/owlSameAs/,hbzlod/orcaHasUrn/,extlod/gnd/,extlod/dewey.nt,enrich/ $RESOURCES http://lobid.org/resource lobid-index-$TIME json-ld-lobid
-sh index.sh $RESOURCES $ES_SERVER $ES_CLUSTER
+sh convert.sh hbzlod/lobid-resources/,hbzlod/owlSameAs/,hbzlod/orcaHasUrn/,extlod/gnd/,extlod/dewey.nt,enrich/ $RESOURCES http://lobid.org/resource lobid-resources-$TIME json-ld-lobid
+sh index.sh $RESOURCES $ES_SERVER $ES_CLUSTER NOALIAS # no alias, index not ready yet, needs items from below
 
 ITEMS=output/json-ld-lobid-items
-sh convert.sh hbzlod/lobid-resources/,enrich/ $ITEMS http://lobid.org/item lobid-index-$TIME json-ld-lobid-item
-sh index.sh $ITEMS $ES_SERVER $ES_CLUSTER
+sh convert.sh hbzlod/lobid-resources/,enrich/ $ITEMS http://lobid.org/item lobid-resources-$TIME json-ld-lobid-item
+sh index.sh $ITEMS $ES_SERVER $ES_CLUSTER ""

--- a/lodmill-ld/pom.xml
+++ b/lodmill-ld/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.lobid</groupId>
 	<artifactId>lodmill-ld</artifactId>
-	<version>1.1.0</version>
+	<version>1.1.1</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lodmill-ld/src/test/java/org/lobid/lodmill/hadoop/IntegrationTestIndexFromHdfsInElasticSearch.java
+++ b/lodmill-ld/src/test/java/org/lobid/lodmill/hadoop/IntegrationTestIndexFromHdfsInElasticSearch.java
@@ -87,7 +87,7 @@ public class IntegrationTestIndexFromHdfsInElasticSearch extends
 		Thread.sleep(INDEX_SLEEP);
 		final SearchResponse response =
 				search(
-						"lobid-resources",
+						"lobid-index",
 						"@graph.http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson.@value",
 						"loft");
 		assertTrue(

--- a/lodmill-ui/project/Build.scala
+++ b/lodmill-ui/project/Build.scala
@@ -10,7 +10,7 @@ object ApplicationBuild extends Build {
     val appDependencies = Seq(
       javaCore,
       "org.elasticsearch" % "elasticsearch" % "0.90.7" withSources(),
-      "org.lobid" % "lodmill-ld" % "1.1.0",
+      "org.lobid" % "lodmill-ld" % "1.1.1",
       "org.scalatest" %% "scalatest" % "1.9.1" % "test"
     )
 


### PR DESCRIPTION
See #191

This pull request fixes an issue with the automatic alias updates: after indexing lobid-resources, the alias was updated before lobid-items were indexed into the same index, resulting in an incomplete index until indexing lobid-items was done.

This pull request also simplifies the alias handling: previously, there was a custom mapping from index names to aliases. Instead, we now just remove the timestamp from the index name to create the alias.

<!---
@huboard:{"order":72.75}
-->
