### PR TITLE
Move config values to config file to simplify staging deployment

### DIFF
--- a/lodmill-ui/app/models/Document.java
+++ b/lodmill-ui/app/models/Document.java
@@ -2,21 +2,17 @@
 
 package models;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.lobid.lodmill.JsonLdConverter;
 import org.lobid.lodmill.JsonLdConverter.Format;
 
 import play.Logger;
-import play.Play;
 import play.libs.Json;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -50,7 +46,7 @@ public class Document {
 	 */
 	public String getSource() {
 		try {
-			final Pair<URL, String> localAndPublicContextUrls = getContextUrls();
+			final Pair<URL, String> localAndPublicContextUrls = index.context();
 			final Map<String, Object> compactJsonLd =
 					sourceAsCompactJsonLd((Map<String, Object>) JSONUtils
 							.fromURL(localAndPublicContextUrls.getLeft()));
@@ -136,19 +132,6 @@ public class Document {
 			Logger.error(x.getMessage(), x);
 		}
 		return result;
-	}
-
-	private Pair<URL, String> getContextUrls() throws MalformedURLException {
-		final String path = "public/contexts";
-		final String file = index.id() + ".json";
-		URL localContextResourceUrl =
-				Play.application().resource("/" + path + "/" + file);
-		if (localContextResourceUrl == null) // no app running, use plain local file
-			localContextResourceUrl = new File(path, file).toURI().toURL();
-		final String publicContextUrl =
-				"http://api.lobid.org"
-						+ controllers.routes.Assets.at("/" + path, file).url();
-		return new ImmutablePair<>(localContextResourceUrl, publicContextUrl);
 	}
 
 }

--- a/lodmill-ui/app/models/Search.java
+++ b/lodmill-ui/app/models/Search.java
@@ -37,9 +37,12 @@ public class Search {
 
 	/** The ElasticSearch server to use. */
 	public static final InetSocketTransportAddress ES_SERVER =
-			new InetSocketTransportAddress("193.30.112.170", 9300); // NOPMD
+			new InetSocketTransportAddress(
+					Index.CONFIG.getString("application.es.server"),
+					Index.CONFIG.getInt("application.es.port"));
 	/** The ElasticSearch cluster to use. */
-	public static final String ES_CLUSTER_NAME = "quaoar";
+	public static final String ES_CLUSTER_NAME = Index.CONFIG
+			.getString("application.es.cluster");
 
 	private static Client productionClient = new TransportClient(
 			ImmutableSettings.settingsBuilder().put("cluster.name", ES_CLUSTER_NAME)

--- a/lodmill-ui/conf/application.conf
+++ b/lodmill-ui/conf/application.conf
@@ -1,7 +1,12 @@
 # This is the main configuration file for the application.
 # ~~~~~
 
-application.version="1.5.2"
+application.version="1.5.3"
+application.url="http://api.lobid.org" #"http://staging.api.lobid.org"
+application.index.suffix="" #"-staging"
+application.es.server="193.30.112.170" #"193.30.112.171"
+application.es.port=9300
+application.es.cluster="quaoar" #"quaoar-test"
 
 # Secret key
 # ~~~~~


### PR DESCRIPTION
Specify in `application.conf`:
- application URL (for context file reference)
- index suffix (e.g. `-staging`)
- elasticsearch server, port, and cluster

With this, all staging-specific changes are in `application.conf`.

This is deployed to staging.

<!---
@huboard:{"order":21.1875}
-->
