### PR TITLE
Don't identify primary topic in external JSON-LD, only internally

### DIFF
--- a/lodmill-ui/app/models/Document.java
+++ b/lodmill-ui/app/models/Document.java
@@ -73,8 +73,12 @@ public class Document {
 	 */
 	public String getSourceWithFullProperties() {
 		try {
-			return JSONUtils
-					.toString(sourceAsCompactJsonLd(new HashMap<String, Object>()));
+			final Map<String, Object> jsonLd =
+					sourceAsCompactJsonLd(new HashMap<String, Object>());
+			final Object graph = jsonLd.get("@graph");
+			if (graph instanceof List && ((List<?>) graph).size() > 1)
+				addPrimaryTopicMetadata(jsonLd);
+			return JSONUtils.toString(jsonLd);
 		} catch (JSONLDProcessingError | IOException e) {
 			e.printStackTrace();
 			return null;
@@ -86,9 +90,6 @@ public class Document {
 			JSONLDProcessingError {
 		final Map<String, Object> jsonLd =
 				(Map<String, Object>) JSONUtils.fromString(source);
-		final Object graph = jsonLd.get("@graph");
-		if (graph instanceof List && ((List<?>) graph).size() > 1)
-			addPrimaryTopicMetadata(jsonLd);
 		return (Map<String, Object>) JSONLD.compact(jsonLd, contextObject);
 	}
 

--- a/lodmill-ui/app/models/queries/LobidItems.java
+++ b/lodmill-ui/app/models/queries/LobidItems.java
@@ -58,7 +58,7 @@ public class LobidItems {
 			try {
 				/*
 				 * The Lobid item IDs contain escaped entities, so we need to URL encode
-				 * the ID. In particular, spaces are encode with '+', not '%2B', so we
+				 * the ID. In particular, spaces are encoded with '+', not '%2B', so we
 				 * take care of that, too:
 				 */
 				final String encodedShortId =

--- a/lodmill-ui/conf/application.conf
+++ b/lodmill-ui/conf/application.conf
@@ -1,7 +1,7 @@
 # This is the main configuration file for the application.
 # ~~~~~
 
-application.version="1.5.3"
+application.version="1.4.1"
 application.url="http://api.lobid.org" #"http://staging.api.lobid.org"
 application.index.suffix="" #"-staging"
 application.es.server="193.30.112.170" #"193.30.112.171"

--- a/lodmill-ui/test/tests/SearchTests.java
+++ b/lodmill-ui/test/tests/SearchTests.java
@@ -625,10 +625,8 @@ public class SearchTests extends SearchTestsHarness {
 			public void run() {
 				final JsonNode jsonObject = Json.parse(call("resource?id=BT000001260"));
 				assertThat(jsonObject.isArray()).isTrue();
-				assertThat(jsonObject.get(0).get("@id").asText()).isEqualTo(
-						"http://lobid.org/resource/BT000001260/about");
-				assertThat(jsonObject.get(0).get("primaryTopic").asText()).isEqualTo(
-						"http://lobid.org/resource/BT000001260");
+				assertThat(jsonObject.get(0).get("@id")).isNull();
+				assertThat(jsonObject.get(0).get("primaryTopic")).isNull();
 			}
 		});
 	}


### PR DESCRIPTION
Identifying the primary topic was originally both for the request in https://github.com/lobid/lodmill/issues/230#issuecomment-32290484 and for #257. It did break Edoweb however, probably due to an issue with parsing named JSON-LD graphs in rdflib. This removes the primary topic from the served JSON-LD, but retains it in the internal format, used by the UI for #257.

Deployed to staging: http://staging.api.lobid.org

<!---
@huboard:{"order":9.09375}
-->
