### PR TITLE
Preserve order when removing duplicates for `format=short`

### DIFF
--- a/lodmill-ui/app/controllers/Application.java
+++ b/lodmill-ui/app/controllers/Application.java
@@ -4,7 +4,7 @@ package controllers;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import models.Document;
@@ -146,7 +146,7 @@ public final class Application extends Controller {
 								withCallback(callback, fullJsonResponse(documents, field)))
 						.put(
 								ResultFormat.SHORT,
-								withCallback(callback, Json.toJson(new HashSet<>(Lists
+								withCallback(callback, Json.toJson(new LinkedHashSet<>(Lists
 										.transform(documents, jsonShort)))))
 						.put(
 								ResultFormat.IDS,

--- a/lodmill-ui/conf/application.conf
+++ b/lodmill-ui/conf/application.conf
@@ -1,7 +1,7 @@
 # This is the main configuration file for the application.
 # ~~~~~
 
-application.version="1.4.1"
+application.version="1.4.2"
 application.url="http://api.lobid.org" #"http://staging.api.lobid.org"
 application.index.suffix="" #"-staging"
 application.es.server="193.30.112.170" #"193.30.112.171"


### PR DESCRIPTION
See #323. Deployed to staging, see:

http://staging.api.lobid.org/resource?name=Mein+Weg+%C3%BCber+die+Pyren%C3%A4en&format=short
http://staging.api.lobid.org/resource?name=Mein+Weg+%C3%BCber+die+Pyren%C3%A4en&format=ids
http://staging.api.lobid.org/resource?name=Mein+Weg+%C3%BCber+die+Pyren%C3%A4en&format=full

All have "Mein Weg über die Pyrenäen" as the top hit. Unlike the `short` format on production:

http://api.lobid.org/resource?name=Mein+Weg+%C3%BCber+die+Pyren%C3%A4en&format=short

<!---
@huboard:{"order":48.0}
-->
