### PR TITLE
Don't filter out undifferentiated persons by default

### DIFF
--- a/lodmill-ui/app/models/queries/Gnd.java
+++ b/lodmill-ui/app/models/queries/Gnd.java
@@ -2,7 +2,6 @@
 
 package models.queries;
 
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.multiMatchQuery;
 
@@ -76,16 +75,8 @@ public class Gnd {
 
 		@Override
 		public QueryBuilder build(final String queryString) {
-			return filterUndifferentiatedPersons(searchAuthor(queryString));
+			return searchAuthor(queryString);
 		}
-
-		static QueryBuilder filterUndifferentiatedPersons(final QueryBuilder query) {
-			return boolQuery().must(query).must(
-					matchQuery("@graph.@type",
-							"http://d-nb.info/standards/elementset/gnd#DifferentiatedPerson")
-							.operator(Operator.AND));
-		}
-
 	}
 
 	/**

--- a/lodmill-ui/test/tests/AutocompleteTests.java
+++ b/lodmill-ui/test/tests/AutocompleteTests.java
@@ -46,11 +46,13 @@ public class AutocompleteTests extends SearchTestsHarness {
 			@Override
 			public void run() {
 				final JsonNode jsonObjectIds =
-						Json.parse(call("person?name=Bach&format=ids"));
+						Json.parse(call("person?name=Bach&format=ids&t="
+								+ "http://d-nb.info/standards/elementset/gnd%23DifferentiatedPerson"));
 				assertThat(jsonObjectIds.isArray()).isTrue();
 				assertThat(jsonObjectIds.size()).isEqualTo(3); // with id: no dupe
 				final JsonNode jsonObjectShort =
-						Json.parse(call("person?name=Bach&format=short"));
+						Json.parse(call("person?name=Bach&format=short&t="
+								+ "http://d-nb.info/standards/elementset/gnd%23DifferentiatedPerson"));
 				assertThat(jsonObjectShort.isArray()).isTrue();
 				assertThat(jsonObjectShort.size()).isEqualTo(2); // just label: dupe
 			}

--- a/lodmill-ui/test/tests/SearchTests.java
+++ b/lodmill-ui/test/tests/SearchTests.java
@@ -317,7 +317,8 @@ public class SearchTests extends SearchTestsHarness {
 			@Override
 			public void run() {
 				final JsonNode jsonObject =
-						Json.parse(call("person?name=bach&format=short"));
+						Json.parse(call("person?name=bach&format=short&t="
+								+ "http://d-nb.info/standards/elementset/gnd%23DifferentiatedPerson"));
 				assertThat(jsonObject.isArray()).isTrue();
 				/* differentiated & *starting* with 'bach' only & no dupes */
 				assertThat(jsonObject.size()).isEqualTo(2);


### PR DESCRIPTION
See #386

Deployed to staging, where now both of these yield a result:

http://staging.api.lobid.org/person?id=108620786
http://staging.api.lobid.org/person?name=Christine+Dimroth

<!---
@huboard:{"order":389.0,"custom_state":""}
-->
