### PR TITLE
Remove discrimination between URIs and literals of identifier

### DIFF
--- a/lodmill-rd/src/main/java/org/lobid/lodmill/RdfModelFileWriter.java
+++ b/lodmill-rd/src/main/java/org/lobid/lodmill/RdfModelFileWriter.java
@@ -24,7 +24,6 @@ import org.culturegraph.mf.framework.annotations.Out;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.hp.hpl.jena.rdf.model.LiteralRequiredException;
 import com.hp.hpl.jena.rdf.model.Model;
 
 /**
@@ -109,20 +108,12 @@ public final class RdfModelFileWriter extends DefaultObjectReceiver<Model>
 					model
 							.listObjectsOfProperty(
 									model.createProperty(filenameUtil.property)).next()
-							.asLiteral().toString();
+							.toString();
 			LOG.debug("Going to store identifier=" + identifier);
 		} catch (NoSuchElementException e) {
 			LOG.warn("No identifier => cannot derive a filename for "
 					+ model.toString());
 			return;
-		} catch (LiteralRequiredException e) {
-			LOG.warn("Identifier is a URI. Derive filename from that URI ... "
-					+ model.toString(), e);
-			identifier =
-					model
-							.listObjectsOfProperty(
-									model.createProperty(filenameUtil.property)).next()
-							.toString();
 		}
 
 		String directory = identifier;


### PR DESCRIPTION
- it is ok if identifier are literals or if they are URIs. Both can be
  stored in the filesystem. This commit removes unnecessary log output
  which was noticed in project https://github.com/hbz/oerworldmap because
  there were URI's (urn's) used.

<!---
@huboard:{"order":404.0,"custom_state":""}
-->
