### PR TITLE
Fix missing results on GND queries over all fields (with `q` param)

### DIFF
--- a/lodmill-ui/app/models/Hit.java
+++ b/lodmill-ui/app/models/Hit.java
@@ -113,6 +113,8 @@ public enum Hit {
 					return value.asText();
 			}
 		}
+		if (fields.contains("_all"))
+			return hit.getId();
 		Logger.warn(String.format("Hit '%s' contains none of the fields: '%s'",
 				hit.getSource(), fields));
 		return null;

--- a/lodmill-ui/app/models/queries/Gnd.java
+++ b/lodmill-ui/app/models/queries/Gnd.java
@@ -26,11 +26,10 @@ public class Gnd {
 	public static class AllFieldsQuery extends AbstractIndexQuery {
 		@Override
 		public List<String> fields() {
-			final List<String> suggestFields =
-			// TODO PersonNameQuery#fields make no sense for subjects
-					new ArrayList<>(new PersonNameQuery().fields());
-			final List<String> searchFields = Arrays.asList("_all");
-			suggestFields.addAll(searchFields);
+			final List<String> suggestFields = new ArrayList<>();
+			suggestFields.addAll(new PersonNameQuery().fields());
+			suggestFields.addAll(new SubjectNameQuery().fields());
+			suggestFields.addAll(Arrays.asList("_all"));
 			return suggestFields;
 		}
 

--- a/lodmill-ui/test/tests/SearchEntitiesNarrowByTypeTests.java
+++ b/lodmill-ui/test/tests/SearchEntitiesNarrowByTypeTests.java
@@ -27,7 +27,7 @@ public class SearchEntitiesNarrowByTypeTests extends SearchTestsHarness {
 	@Test public void newspapers() { search("resource?q=*&t=Newspaper", 1); }
 	@Test public void differentiatedPersons() { search("person?q=*&t=DifferentiatedPerson", 9); }
 	@Test public void undifferentiatedPersons() { search("person?q=*&t=UndifferentiatedPerson", 4); }
-	@Test public void persons() { search("person?q=*", 9+4); }
+	@Test public void subjects() { search("subject?q=*", 17); }
 	@Test public void journalsUri() { search("resource?q=*&t=http://purl.org/ontology/bibo/Journal", 1); }
 	@Test public void newspapersUri() { search("resource?q=*&t=http://purl.org/ontology/bibo/Newspaper", 1); }
 	//@formatter:on


### PR DESCRIPTION
Deployed to staging:

http://api.lobid.org/subject?q=Informatik (issue: 0 results)
http://staging.api.lobid.org/subject?q=Informatik (fix: > 50 results)

Which is an extreme case of a general issue with all `q` queries against GND:

http://api.lobid.org/subject?q=Essen (issue: 4 results)
http://staging.api.lobid.org/subject?q=Essen (fix: > 50 results)

Thanks to @literarymachine for reporting the issue.
