### PR TITLE
Rename property to the proper one

### DIFF
--- a/lodmill-ui/public/contexts/lobid-organisations.json
+++ b/lodmill-ui/public/contexts/lobid-organisations.json
@@ -5,7 +5,7 @@
       "name": "http://xmlns.com/foaf/0.1/name",
       "isil": "http://purl.org/lobid/lv#isil",
       "prefLabel": "http://www.w3.org/2004/02/skos/core#prefLabel",
-      "alternateLabel": "http://www.w3.org/2004/02/skos/core#alternateLabel",
+      "altLabel": "http://www.w3.org/2004/02/skos/core#altLabel",
       "location":
       {
          "@id": "http://www.w3.org/2003/01/geo/wgs84_pos#location",


### PR DESCRIPTION
- fix the missing context information , s.: #304

The non-ZDB-Isil data had wrongly `skos:alternateLabel` as property, when it should be `skos:altLabel`. I changed this static data and copied it into hdfs. The data cannot be seen at them moment because of #417 - when fixed have a look at e.g. http://lobid.org/organisation/LB-ZmNDL. 

So now we use the `skos:altLabel` for both: the static non-ZDB data and as of late for the ZDB-Isil data.

Will be deployed after this weekend.

<!---
@huboard:{"order":75.1875,"custom_state":""}
-->
