### PR TITLE
Add git stash to avoid possibly breaking builds

### DIFF
--- a/lodmill-rd/doc/scripts/hbz01/startHbz012lobidUpdateMysqlInParallel.sh
+++ b/lodmill-rd/doc/scripts/hbz01/startHbz012lobidUpdateMysqlInParallel.sh
@@ -12,13 +12,15 @@ BRANCH=$1
 if [ -z $BRANCH ]; then
         BRANCH="master"
 fi
-echo "Going checkout $BRANCH ..." 
-cd ../../.. ; git checkout $BRANCH ; git pull;  mvn assembly:assembly
+echo "Going checkout $BRANCH ..."
+git stash # to avoid possible conflicts
+cd ../../.. ; git checkout $BRANCH ; git pull
+mvn assembly:assembly -DdescriptorId=jar-with-dependencies  -Dwith-DskipTests=true -Dmysql.classifier=linux-amd64 -Dmysql.port=33061
 JAR=$(basename $(ls target/lodmill-rd-*jar-with-dependencies.jar))
 echo $JAR
 cd -
 # TODO should be done with maven: overwrite the flux-command from metafacture with that from lodmill 
-cd ../../../target/ ; cp ../src/main/resources/flux-commands.properties ./; jar uf $JAR flux-commands.properties; cd -
+cd ../../../target/ ; cp ../src/main/resources/flux-commands.properties ./; jar uf $JAR flux-commands.properties; cp ../src/main/resources/morph-functions.properties ./ ; jar uf $JAR morph-functions.properties ; mkdir schemata; cp ../src/main/resources/schemata/* schemata/ ; jar uf $JAR schemata/* ; cd -
 
 LODMILL_RD_JAR=../../../target/$JAR
 


### PR DESCRIPTION
- copy more configs into jar
- add hardcoded linux-amd-64 parameter to maven build
  Would be better to use variable and dynamical configuration
  of OS distribution - but then this is easier for now and we know
  on which OS we start this skript.
