### PR TITLE
Add create index with mappings

### DIFF
--- a/lodmill-ld/doc/scripts/index.sh
+++ b/lodmill-ld/doc/scripts/index.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PRINT_TIME() {
  printf "\n$(date '+%y/%m/%d %H:%M:%S')"
@@ -19,8 +19,9 @@ INDEX_ALIAS=$4
 INDEX_NAME=$5
 
 ES_URL="http://$ES_SERVER:9200/$INDEX_NAME/"
-PRINT_TIME ;printf "Create index in $ES_URL\n"
-curl -XPUT "$ES_URL"
+
+PRINT_TIME ;printf "Create index with mapping in $ES_URL\n"
+curl -XPUT "$ES_URL" -d @../../src/main/resources/index-config.json
 
 PRINT_TIME ; printf "Start stopping index refreshing ... \n" 
 curl -XPUT "$ES_URL"/_settings -d '{


### PR DESCRIPTION
See #331, #508

Since via curl an index is created to be able
to set refreh interavll to -1, the java program
doesn't create an index anymore and with that no
mapping is set.
We need this settings and so we give them via curl.
