### PR TITLE
Outcomment provenance and about URIs

### DIFF
--- a/lodmill-rd/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/lodmill-rd/src/main/resources/morph-hbz01-to-lobid.xml
@@ -83,11 +83,11 @@
 			<data source="010-1.a|529z1.9|@idTitleSeries"/>
 		</combine>
 		<!-- ####################### -->
-		<!-- ####### provenance -->
+		<!-- ####### provenance not used for now, see https://github.com/lobid/lodmill/issues/541-->
 		<!-- ####################### -->
-		<data source="@idzdb" name="@idzdbProvenance">
+		<!-- <data source="@idzdb" name="@idzdbProvenance">
 			<regexp match="(.*)" format="$[ns-lobid-resource]${1}/about"/>
-		</data>
+		</data> 
 		<data source="@idzdbProvenance" name="~rdf:subject"/>
 		<data source="@idzdb" name="http://xmlns.com/foaf/0.1/primaryTopic">
 			<regexp match="(.*)" format="$[ns-lobid-resource]${1}"/>
@@ -138,7 +138,7 @@
 			<data source="@id" name="id">
 				<regexp match="(.*)" format="${1}"/>
 			</data>
-		</combine>
+		</combine>-->
 		<!-- ####################### -->
 		<!-- ####### Set main subject uri -->
 		<!-- ####################### -->

--- a/lodmill-rd/src/test/resources/CT003012479.nt
+++ b/lodmill-rd/src/test/resources/CT003012479.nt
@@ -55,5 +55,3 @@
 <http://lobid.org/resource/CT003012479> <http://id.loc.gov/vocabulary/relators/act> <http://d-nb.info/gnd/142061166> .
 <http://lobid.org/resource/CT003012479> <http://purl.org/dc/terms/hasVersion> <http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125> .
 <http://lobid.org/resource/CT003012479> <http://id.loc.gov/vocabulary/relators/act> <http://d-nb.info/gnd/141927135> .
-<http://lobid.org/resource/CT003012479/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/CT003012479/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/CT003012479> .

--- a/lodmill-rd/src/test/resources/hbz01.nt
+++ b/lodmill-rd/src/test/resources/hbz01.nt
@@ -1477,8 +1477,6 @@
 <http://lobid.org/item/ZDB6211-x:DE-Bo133:Z%20848> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bo133> .
 <http://lobid.org/item/ZDB6211-x:DE-Bo133:Z%20848> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/ZDB6211-x:DE-Bo133:Z%20848> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/ZDB6211-x:DE-Bo133:Z%20848/about> .
-<http://lobid.org/resource/BT000003404/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/BT000003404/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/BT000003404> .
 <http://lobid.org/resource/BT000003404> <http://iflastandards.info/ns/isbd/elements/P1053> "Kt." .
 <http://lobid.org/resource/BT000003404> <http://purl.org/dc/elements/1.1/publisher> "Reise- u. Verkehrsverl." .
 <http://lobid.org/resource/BT000003404> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/BT000100437> .
@@ -1507,16 +1505,12 @@
 <http://lobid.org/resource/BT000003404> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000003404> .
 <http://lobid.org/resource/BT000003404> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/BT000003404/about> .
 <http://lobid.org/resource/BT000003404> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000003404> .
-<http://lobid.org/resource/BT000067443/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/BT000067443/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/BT000067443> .
 <http://lobid.org/resource/BT000067443> <http://purl.org/dc/terms/bibliographicCitation> "Kiebitz. - 6 (1986), S. 29-36, S. 63-67" .
 <http://lobid.org/resource/BT000067443> <http://purl.org/dc/terms/creator> <http://d-nb.info/gnd/118033948> .
 <http://lobid.org/resource/BT000067443> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT006990419> .
 <http://lobid.org/resource/BT000067443> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/NWBib> .
 <http://lobid.org/resource/BT000067443> <http://purl.org/dc/terms/issued> "1986" .
 <http://lobid.org/resource/BT000067443> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
-<http://lobid.org/resource/BT000067443> <http://purl.org/dc/terms/spatial> <http://linkedgeodata.org/triplify/relation157769> .
-<http://lobid.org/resource/BT000067443> <http://purl.org/dc/terms/spatial> <http://sws.geonames.org/2939945/> .
 <http://lobid.org/resource/BT000067443> <http://purl.org/dc/terms/title> "Bestandsaufnahme der Amphibien im Raum Coesfeld-Billerbeck" .
 <http://lobid.org/resource/BT000067443> <http://purl.org/lobid/lv#hbzID> "BT000067443" .
 <http://lobid.org/resource/BT000067443> <http://purl.org/lobid/lv#nwbibsubject> <http://purl.org/lobid/nwbib#s163060> .
@@ -1530,8 +1524,6 @@
 <http://lobid.org/resource/BT000067443> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000067443> .
 <http://lobid.org/resource/BT000100437> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/BT000003404> .
 <http://lobid.org/resource/BT000100437> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/BT000128754/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/BT000128754/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/BT000128754> .
 <http://lobid.org/resource/BT000128754> <http://purl.org/dc/terms/abstract> "Erinnerungen an d. 1. FC K\u00F6ln u. Borussia M\u00F6nchengladbach" .
 <http://lobid.org/resource/BT000128754> <http://purl.org/dc/terms/bibliographicCitation> "1996; S. 101-[108]" .
 <http://lobid.org/resource/BT000128754> <http://purl.org/dc/terms/bibliographicCitation> "Nach dem Spiel ist vor dem Spiel : die wunderbare Welt des Fu\u00DFballs / Wolfgang Frank (Hg.); Orig.-Ausg.; 1996; S. 101-[108]" .
@@ -1557,8 +1549,6 @@
 <http://lobid.org/resource/BT000128754> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000128754> .
 <http://lobid.org/resource/BT000128754> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/BT000128754/about> .
 <http://lobid.org/resource/BT000128754> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000128754> .
-<http://lobid.org/resource/CT003012479/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/CT003012479/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/CT003012479> .
 <http://lobid.org/resource/CT003012479> <http://id.loc.gov/vocabulary/relators/act> <http://d-nb.info/gnd/118512536> .
 <http://lobid.org/resource/CT003012479> <http://id.loc.gov/vocabulary/relators/act> <http://d-nb.info/gnd/141834919> .
 <http://lobid.org/resource/CT003012479> <http://id.loc.gov/vocabulary/relators/act> <http://d-nb.info/gnd/141889810> .
@@ -1613,16 +1603,12 @@
 <http://lobid.org/resource/CT003012479> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-CT003012479> .
 <http://lobid.org/resource/CT003012479> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/CT003012479/about> .
 <http://lobid.org/resource/CT003012479> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DCT003012479> .
-<http://lobid.org/resource/HT000009600/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT000009600/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT000009600> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/lobid/lv#hbzID> "HT000009600" .
 <http://lobid.org/resource/HT000009600> <http://purl.org/ontology/bibo/oclcnum> "263589870" .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/6211-x> .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/2002/07/owl#sameAs> <http://lobid.org/resource/ZDB6211-x> .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/263589870> .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT000009600/about> .
-<http://lobid.org/resource/HT000290078/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT000290078/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT000290078> .
 <http://lobid.org/resource/HT000290078> <http://iflastandards.info/ns/isbd/elements/P1053> "X, 99 S. : GRAPH. DARST." .
 <http://lobid.org/resource/HT000290078> <http://purl.org/dc/elements/1.1/publisher> "HOELDER-PICHLER-TEMPSKY" .
 <http://lobid.org/resource/HT000290078> <http://purl.org/dc/elements/1.1/publisher> "LEYKAM" .
@@ -1644,8 +1630,6 @@
 <http://lobid.org/resource/HT000290078> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT000290078> .
 <http://lobid.org/resource/HT000290078> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT000290078/about> .
 <http://lobid.org/resource/HT000290078> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT000290078> .
-<http://lobid.org/resource/HT001310215/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT001310215/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT001310215> .
 <http://lobid.org/resource/HT001310215> <http://purl.org/dc/elements/1.1/publisher> "AMERICAN DENTAL ASSOCIATION" .
 <http://lobid.org/resource/HT001310215> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/177572388> .
 <http://lobid.org/resource/HT001310215> <http://purl.org/dc/terms/creator> <http://d-nb.info/gnd/37460-X> .
@@ -1669,8 +1653,6 @@
 <http://lobid.org/resource/HT001373475> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
 <http://lobid.org/resource/HT001381485> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT001898812> .
 <http://lobid.org/resource/HT001381485> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/HT001898812/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT001898812/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT001898812> .
 <http://lobid.org/resource/HT001898812> <http://iflastandards.info/ns/isbd/elements/P1053> "XVIII, 1306 S." .
 <http://lobid.org/resource/HT001898812> <http://purl.org/dc/elements/1.1/publisher> "Verl. Enzyklop\u00E4die [u.a.]" .
 <http://lobid.org/resource/HT001898812> <http://purl.org/dc/terms/alternative> "Wie\u0142ki slownik polsko-niemiecki" .
@@ -1719,8 +1701,6 @@
 <http://lobid.org/resource/HT002619538> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
 <http://lobid.org/resource/HT002808565> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/TT001671747> .
 <http://lobid.org/resource/HT002808565> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/HT004944075/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT004944075/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT004944075> .
 <http://lobid.org/resource/HT004944075> <http://purl.org/dc/elements/1.1/publisher> "UN" .
 <http://lobid.org/resource/HT004944075> <http://purl.org/dc/terms/alternative> "Bulletin annuel de statistiques des transports pour l'Europe et l'Am\u00E9rique du Nord" .
 <http://lobid.org/resource/HT004944075> <http://purl.org/dc/terms/alternative> "E\u017Eegodnyj bjulleten' statistiki transporta dlja Evropy i Severnoj Ameriki" .
@@ -1750,8 +1730,6 @@
 <http://lobid.org/resource/HT004944075> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT004944075> .
 <http://lobid.org/resource/HT004984061> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT015183529> .
 <http://lobid.org/resource/HT004984061> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/HT006266886/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT006266886/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT006266886> .
 <http://lobid.org/resource/HT006266886> <http://id.loc.gov/vocabulary/relators/act> <http://d-nb.info/gnd/120454874> .
 <http://lobid.org/resource/HT006266886> <http://id.loc.gov/vocabulary/relators/act> <http://d-nb.info/gnd/141618302> .
 <http://lobid.org/resource/HT006266886> <http://id.loc.gov/vocabulary/relators/act> <http://d-nb.info/gnd/141649429> .
@@ -1793,8 +1771,6 @@
 <http://lobid.org/resource/HT006886479> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
 <http://lobid.org/resource/HT007527436> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT000009600> .
 <http://lobid.org/resource/HT007527436> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/HT009719670/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT009719670/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT009719670> .
 <http://lobid.org/resource/HT009719670> <http://purl.org/dc/elements/1.1/publisher> "Hatier/Didier" .
 <http://lobid.org/resource/HT009719670> <http://purl.org/dc/terms/bibliographicCitation> "Erschienen: 1 - 2, jeweils Videokass. u. Begleith." .
 <http://lobid.org/resource/HT009719670> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/11860225X> .
@@ -1816,8 +1792,6 @@
 <http://lobid.org/resource/HT009719670> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT009719670> .
 <http://lobid.org/resource/HT009719670> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT009719670/about> .
 <http://lobid.org/resource/HT009719670> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT009719670> .
-<http://lobid.org/resource/HT010662586/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT010662586/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT010662586> .
 <http://lobid.org/resource/HT010662586> <http://iflastandards.info/ns/isbd/elements/P1053> "23 p." .
 <http://lobid.org/resource/HT010662586> <http://purl.org/dc/elements/1.1/publisher> "Leicester Univ. Pr." .
 <http://lobid.org/resource/HT010662586> <http://purl.org/dc/terms/creator> <http://d-nb.info/gnd/118839055> .
@@ -1835,16 +1809,12 @@
 <http://lobid.org/resource/HT010662586> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT010662586> .
 <http://lobid.org/resource/HT010662586> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT010662586/about> .
 <http://lobid.org/resource/HT010662586> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT010662586> .
-<http://lobid.org/resource/HT010726584/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT010726584/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT010726584> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#hbzID> "HT010726584" .
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/1472746-8> .
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/2002/07/owl#sameAs> <http://lobid.org/resource/ZDB1472746-8> .
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT010726584/about> .
 <http://lobid.org/resource/HT012299746> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT000009600> .
 <http://lobid.org/resource/HT012299746> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/HT012926727/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT012926727/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT012926727> .
 <http://lobid.org/resource/HT012926727> <http://iflastandards.info/ns/isbd/elements/P1053> "1 Kt.-Beil." .
 <http://lobid.org/resource/HT012926727> <http://iflastandards.info/ns/isbd/elements/P1053> "XIV, 514 S. : graph. Darst., Kt." .
 <http://lobid.org/resource/HT012926727> <http://purl.org/dc/elements/1.1/publisher> "Springer" .
@@ -1909,8 +1879,6 @@
 <http://lobid.org/resource/HT012926727> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012926727> .
 <http://lobid.org/resource/HT012926727> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT012926727/about> .
 <http://lobid.org/resource/HT012926727> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT012926727> .
-<http://lobid.org/resource/HT013304490/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT013304490/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT013304490> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/lobid/lv#hbzID> "HT013304490" .
 <http://lobid.org/resource/HT013304490> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2073588-1> .
 <http://lobid.org/resource/HT013304490> <http://www.w3.org/2002/07/owl#sameAs> <http://lobid.org/resource/ZDB2073588-1> .
@@ -1919,8 +1887,6 @@
 <http://lobid.org/resource/HT013304885> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
 <http://lobid.org/resource/HT013370531> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT015865114> .
 <http://lobid.org/resource/HT013370531> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/HT013911008/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT013911008/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT013911008> .
 <http://lobid.org/resource/HT013911008> <http://iflastandards.info/ns/isbd/elements/P1053> "1 CD-ROM ; 12 cm + 1 Beih. [6] S." .
 <http://lobid.org/resource/HT013911008> <http://purl.org/dc/elements/1.1/publisher> "Eutropia" .
 <http://lobid.org/resource/HT013911008> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT013911051> .
@@ -1945,8 +1911,6 @@
 <http://lobid.org/resource/HT013911008> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013911008> .
 <http://lobid.org/resource/HT013911051> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT013911008> .
 <http://lobid.org/resource/HT013911051> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/HT014015351/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT014015351/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT014015351> .
 <http://lobid.org/resource/HT014015351> <http://id.loc.gov/vocabulary/relators/hnr> <http://d-nb.info/gnd/136788548> .
 <http://lobid.org/resource/HT014015351> <http://iflastandards.info/ns/isbd/elements/P1053> "324 S. : Ill." .
 <http://lobid.org/resource/HT014015351> <http://purl.org/dc/elements/1.1/publisher> "Fink" .
@@ -1982,8 +1946,6 @@
 <http://lobid.org/resource/HT014015351> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014015351> .
 <http://lobid.org/resource/HT014015351> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT014015351/about> .
 <http://lobid.org/resource/HT014015351> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014015351> .
-<http://lobid.org/resource/HT014046679/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT014046679/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT014046679> .
 <http://lobid.org/resource/HT014046679> <http://iflastandards.info/ns/isbd/elements/P1053> "1 Spiel (Inhalt: 1 Spielanleitung, 100 Situationskarten: 60 f\u00FCr Frauen, 40 f\u00FCr M\u00E4dchen (ab 12 J.). 90 Brave-Karten, 90 B\u00F6se-Karten)" .
 <http://lobid.org/resource/HT014046679> <http://purl.org/dc/elements/1.1/publisher> "INVENTION" .
 <http://lobid.org/resource/HT014046679> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/175894612> .
@@ -2005,8 +1967,6 @@
 <http://lobid.org/resource/HT014046679> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014046679> .
 <http://lobid.org/resource/HT014046679> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT014046679/about> .
 <http://lobid.org/resource/HT014046679> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014046679> .
-<http://lobid.org/resource/HT014525099/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT014525099/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT014525099> .
 <http://lobid.org/resource/HT014525099> <http://iflastandards.info/ns/isbd/elements/P1053> "2 Schallpl. : 33 UpM, stereo ; 30 cm" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/dc/elements/1.1/publisher> "Dt. Schallplatten" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/dc/terms/creator> <http://d-nb.info/gnd/118500546> .
@@ -2032,8 +1992,6 @@
 <http://lobid.org/resource/HT014525099> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014525099> .
 <http://lobid.org/resource/HT014525099> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT014525099/about> .
 <http://lobid.org/resource/HT014525099> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014525099> .
-<http://lobid.org/resource/HT014997977/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT014997977/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT014997977> .
 <http://lobid.org/resource/HT014997977> <http://iflastandards.info/ns/isbd/elements/P1053> "15, [14] S. : graph. Darst." .
 <http://lobid.org/resource/HT014997977> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/10048424-4> .
 <http://lobid.org/resource/HT014997977> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/2092393-4> .
@@ -2063,8 +2021,6 @@
 <http://lobid.org/resource/HT014997977> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014997977> .
 <http://lobid.org/resource/HT014997977> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT014997977/about> .
 <http://lobid.org/resource/HT014997977> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014997977> .
-<http://lobid.org/resource/HT015082724/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT015082724/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT015082724> .
 <http://lobid.org/resource/HT015082724> <http://purl.org/dc/elements/1.1/publisher> "Amersfoort" .
 <http://lobid.org/resource/HT015082724> <http://purl.org/dc/elements/1.1/publisher> "Groningen" .
 <http://lobid.org/resource/HT015082724> <http://purl.org/dc/elements/1.1/publisher> "Noordhoff" .
@@ -2093,8 +2049,6 @@
 <http://lobid.org/resource/HT015082724> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015082724> .
 <http://lobid.org/resource/HT015082724> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT015082724/about> .
 <http://lobid.org/resource/HT015082724> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015082724> .
-<http://lobid.org/resource/HT015183529/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT015183529/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT015183529> .
 <http://lobid.org/resource/HT015183529> <http://iflastandards.info/ns/isbd/elements/P1053> "LV, 225 S. : Kt." .
 <http://lobid.org/resource/HT015183529> <http://purl.org/dc/elements/1.1/publisher> "Cambridge Univ. Press" .
 <http://lobid.org/resource/HT015183529> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/119468476> .
@@ -2120,8 +2074,6 @@
 <http://lobid.org/resource/HT015183529> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015183529> .
 <http://lobid.org/resource/HT015183529> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT015183529/about> .
 <http://lobid.org/resource/HT015183529> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015183529> .
-<http://lobid.org/resource/HT015414894/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT015414894/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT015414894> .
 <http://lobid.org/resource/HT015414894> <http://purl.org/dc/terms/bibliographicCitation> "2002; S. 80 - 93" .
 <http://lobid.org/resource/HT015414894> <http://purl.org/dc/terms/bibliographicCitation> "Medien und Terrorismus; Christian Schicha ... (Hg.); 2002; S. 80 - 93" .
 <http://lobid.org/resource/HT015414894> <http://purl.org/dc/terms/bibliographicCitation> "Medien und Terrorismus; S. 80 - 93" .
@@ -2145,8 +2097,6 @@
 <http://lobid.org/resource/HT015414894> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015414894> .
 <http://lobid.org/resource/HT015414894> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT015414894/about> .
 <http://lobid.org/resource/HT015414894> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015414894> .
-<http://lobid.org/resource/HT015865114/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT015865114/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT015865114> .
 <http://lobid.org/resource/HT015865114> <http://purl.org/dc/elements/1.1/publisher> "Buchner" .
 <http://lobid.org/resource/HT015865114> <http://purl.org/dc/terms/bibliographicCitation> "Sch\u00FCler- und Lehrerbd." .
 <http://lobid.org/resource/HT015865114> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/105667129> .
@@ -2174,8 +2124,6 @@
 <http://lobid.org/resource/HT015865114> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015865114> .
 <http://lobid.org/resource/HT015865114> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT015865114/about> .
 <http://lobid.org/resource/HT015865114> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015865114> .
-<http://lobid.org/resource/HT015894164/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT015894164/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT015894164> .
 <http://lobid.org/resource/HT015894164> <http://iflastandards.info/ns/isbd/elements/P1053> "88 p." .
 <http://lobid.org/resource/HT015894164> <http://iflastandards.info/ns/isbd/elements/P1053> "ill." .
 <http://lobid.org/resource/HT015894164> <http://purl.org/dc/elements/1.1/isPartOf> "Examens en mati\u00E8re de coop\u00E9ration pour le d\u00E9veloppement" .
@@ -2227,8 +2175,6 @@
 <http://lobid.org/resource/HT015894164> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015894164> .
 <http://lobid.org/resource/HT015894164> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT015894164/about> .
 <http://lobid.org/resource/HT015894164> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015894164> .
-<http://lobid.org/resource/HT016382441/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT016382441/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT016382441> .
 <http://lobid.org/resource/HT016382441> <http://iflastandards.info/ns/isbd/elements/P1053> "1 DVD-ROM (12 cm)" .
 <http://lobid.org/resource/HT016382441> <http://iflastandards.info/ns/isbd/elements/P1053> "418 S. : zahlr. Ill., graph. Darst." .
 <http://lobid.org/resource/HT016382441> <http://purl.org/dc/elements/1.1/publisher> "Wiley-VCH" .
@@ -2277,8 +2223,6 @@
 <http://lobid.org/resource/HT016382441> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT016382441/about> .
 <http://lobid.org/resource/HT016382441> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016382441> .
 <http://lobid.org/resource/HT016511663> <http://purl.org/dc/terms/hasFormat> <http://lobid.org/resource/CT003012479> .
-<http://lobid.org/resource/HT016545462/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT016545462/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT016545462> .
 <http://lobid.org/resource/HT016545462> <http://purl.org/dc/elements/1.1/publisher> "Heimatverein der Gemeinde Nordkirchen e. V:" .
 <http://lobid.org/resource/HT016545462> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/NWBib> .
 <http://lobid.org/resource/HT016545462> <http://purl.org/dc/terms/issued> "9999" .
@@ -2299,8 +2243,6 @@
 <http://lobid.org/resource/HT016545462> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016545462> .
 <http://lobid.org/resource/HT016545462> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT016545462/about> .
 <http://lobid.org/resource/HT016545462> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016545462> .
-<http://lobid.org/resource/HT016608165/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT016608165/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT016608165> .
 <http://lobid.org/resource/HT016608165> <http://purl.org/dc/terms/bibliographicCitation> "1980" .
 <http://lobid.org/resource/HT016608165> <http://purl.org/dc/terms/bibliographicCitation> "M\u00E9lodies" .
 <http://lobid.org/resource/HT016608165> <http://purl.org/dc/terms/bibliographicCitation> "M\u00E9lodies; Claude Debussy; 1980" .
@@ -2327,8 +2269,6 @@
 <http://lobid.org/resource/HT016608165> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016608165> .
 <http://lobid.org/resource/HT017290519> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/CT003012479> .
 <http://lobid.org/resource/HT017290519> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/HT017468042/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT017468042/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT017468042> .
 <http://lobid.org/resource/HT017468042> <http://iflastandards.info/ns/isbd/elements/P1053> "1 Kt. : grenzkolor., fl\u00E4chenkolor., Kupferst." .
 <http://lobid.org/resource/HT017468042> <http://iflastandards.info/ns/isbd/elements/P1053> "46 x 48 cm" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/dc/elements/1.1/publisher> "Homannianos Heredes" .
@@ -2349,8 +2289,6 @@
 <http://lobid.org/resource/HT017468042> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017468042> .
 <http://lobid.org/resource/HT017468042> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT017468042/about> .
 <http://lobid.org/resource/HT017468042> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT017468042> .
-<http://lobid.org/resource/HT018131501/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT018131501/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT018131501> .
 <http://lobid.org/resource/HT018131501> <http://purl.org/dc/terms/bibliographicCitation> "34 (2014),1, S. 14-15" .
 <http://lobid.org/resource/HT018131501> <http://purl.org/dc/terms/bibliographicCitation> "<<Der>> Gie\u00DFerjunge; 34 (2014),1, S. 14-15" .
 <http://lobid.org/resource/HT018131501> <http://purl.org/dc/terms/creator> <http://d-nb.info/gnd/124348165> .
@@ -2376,8 +2314,6 @@
 <http://lobid.org/resource/HT018131501> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018131501> .
 <http://lobid.org/resource/HT018131501> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT018131501/about> .
 <http://lobid.org/resource/HT018131501> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018131501> .
-<http://lobid.org/resource/HT018187026/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/HT018187026/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/HT018187026> .
 <http://lobid.org/resource/HT018187026> <http://purl.org/dc/elements/1.1/publisher> "Logos-Verl." .
 <http://lobid.org/resource/HT018187026> <http://purl.org/dc/terms/issued> "2013 - " .
 <http://lobid.org/resource/HT018187026> <http://purl.org/dc/terms/issued> "2013" .
@@ -2399,8 +2335,6 @@
 <http://lobid.org/resource/HT018187026> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018187026> .
 <http://lobid.org/resource/HT018187026> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT018187026/about> .
 <http://lobid.org/resource/HT018187026> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018187026> .
-<http://lobid.org/resource/TT000075751/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/TT000075751/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/TT000075751> .
 <http://lobid.org/resource/TT000075751> <http://id.loc.gov/vocabulary/relators/sng> <http://d-nb.info/gnd/134782852> .
 <http://lobid.org/resource/TT000075751> <http://id.loc.gov/vocabulary/relators/sng> <http://d-nb.info/gnd/13482167X> .
 <http://lobid.org/resource/TT000075751> <http://id.loc.gov/vocabulary/relators/sng> <http://d-nb.info/gnd/134926285> .
@@ -2429,8 +2363,6 @@
 <http://lobid.org/resource/TT000075751> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT000075751> .
 <http://lobid.org/resource/TT001197763> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/TT001230001> .
 <http://lobid.org/resource/TT001197763> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/TT001210514/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/TT001210514/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/TT001210514> .
 <http://lobid.org/resource/TT001210514> <http://purl.org/dc/elements/1.1/publisher> "Blindenhochschulb\u00FCcherei" .
 <http://lobid.org/resource/TT001210514> <http://purl.org/dc/terms/creator> <http://d-nb.info/gnd/118551655> .
 <http://lobid.org/resource/TT001210514> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -2450,8 +2382,6 @@
 <http://lobid.org/resource/TT001210514> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001210514> .
 <http://lobid.org/resource/TT001210514> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/TT001210514/about> .
 <http://lobid.org/resource/TT001210514> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001210514> .
-<http://lobid.org/resource/TT001230001/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/TT001230001/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/TT001230001> .
 <http://lobid.org/resource/TT001230001> <http://iflastandards.info/ns/isbd/elements/P1053> "[8] Bl., 414, [1] S. : Ill." .
 <http://lobid.org/resource/TT001230001> <http://purl.org/dc/elements/1.1/publisher> "Praetorius" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/118577018> .
@@ -2477,8 +2407,6 @@
 <http://lobid.org/resource/TT001230001> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001230001> .
 <http://lobid.org/resource/TT001230001> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/TT001230001/about> .
 <http://lobid.org/resource/TT001230001> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001230001> .
-<http://lobid.org/resource/TT001671747/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/TT001671747/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/TT001671747> .
 <http://lobid.org/resource/TT001671747> <http://iflastandards.info/ns/isbd/elements/P1053> "[2] Bl. : graph. Darst., Kt." .
 <http://lobid.org/resource/TT001671747> <http://purl.org/dc/elements/1.1/publisher> "Aschendorff" .
 <http://lobid.org/resource/TT001671747> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/137082479> .
@@ -2514,8 +2442,6 @@
 <http://lobid.org/resource/TT001671747> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001671747> .
 <http://lobid.org/resource/TT001671747> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/TT001671747/about> .
 <http://lobid.org/resource/TT001671747> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001671747> .
-<http://lobid.org/resource/TT001726537/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/TT001726537/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/TT001726537> .
 <http://lobid.org/resource/TT001726537> <http://iflastandards.info/ns/isbd/elements/P1053> "[2] Bl., 116 S. : Ill. (Kupfert.)" .
 <http://lobid.org/resource/TT001726537> <http://purl.org/dc/elements/1.1/publisher> "Delpeuck" .
 <http://lobid.org/resource/TT001726537> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/115541802> .
@@ -2536,8 +2462,6 @@
 <http://lobid.org/resource/TT001726537> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001726537> .
 <http://lobid.org/resource/TT001726537> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/TT001726537/about> .
 <http://lobid.org/resource/TT001726537> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001726537> .
-<http://lobid.org/resource/TT003059252/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/TT003059252/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/TT003059252> .
 <http://lobid.org/resource/TT003059252> <http://iflastandards.info/ns/isbd/elements/P1053> "1 Video (VHS, 55 min.) : farb.; stereo" .
 <http://lobid.org/resource/TT003059252> <http://purl.org/dc/elements/1.1/publisher> "Apple Films" .
 <http://lobid.org/resource/TT003059252> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/2005535-3> .
@@ -2560,8 +2484,6 @@
 <http://lobid.org/resource/TT003059252> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT003059252> .
 <http://lobid.org/resource/TT003059252> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/TT003059252/about> .
 <http://lobid.org/resource/TT003059252> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT003059252> .
-<http://lobid.org/resource/ZDB1472746-8/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/ZDB1472746-8/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/ZDB1472746-8> .
 <http://lobid.org/resource/ZDB1472746-8> <http://purl.org/dc/elements/1.1/publisher> "American Institute of Physics" .
 <http://lobid.org/resource/ZDB1472746-8> <http://purl.org/dc/terms/hasVersion> <http://www.bibliothek.uni-regensburg.de/ezeit/?1472746> .
 <http://lobid.org/resource/ZDB1472746-8> <http://purl.org/dc/terms/issued> "1994 - " .
@@ -2625,8 +2547,6 @@
 <http://lobid.org/resource/ZDB1472746-8> <http://www.w3.org/2002/07/owl#sameAs> <http://lobid.org/resource/ZDB1472746-8> .
 <http://lobid.org/resource/ZDB1472746-8> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/ZDB1472746-8/about> .
 <http://lobid.org/resource/ZDB1472746-8> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT010726584> .
-<http://lobid.org/resource/ZDB2073588-1/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/ZDB2073588-1/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/ZDB2073588-1> .
 <http://lobid.org/resource/ZDB2073588-1> <http://purl.org/dc/elements/1.1/publisher> "Ebner" .
 <http://lobid.org/resource/ZDB2073588-1> <http://purl.org/dc/terms/bibliographicCitation> "viertelj\u00E4hrl." .
 <http://lobid.org/resource/ZDB2073588-1> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT013304885> .
@@ -2662,8 +2582,6 @@
 <http://lobid.org/resource/ZDB2073588-1> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/635743319> .
 <http://lobid.org/resource/ZDB2073588-1> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/ZDB2073588-1/about> .
 <http://lobid.org/resource/ZDB2073588-1> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013304490> .
-<http://lobid.org/resource/ZDB6211-x/about> <http://vocab.deri.ie/void#inDataset> <http://lobid.org/dataset/resource> .
-<http://lobid.org/resource/ZDB6211-x/about> <http://xmlns.com/foaf/0.1/primaryTopic> <http://lobid.org/resource/ZDB6211-x> .
 <http://lobid.org/resource/ZDB6211-x> <http://purl.org/dc/elements/1.1/publisher> "DAG" .
 <http://lobid.org/resource/ZDB6211-x> <http://purl.org/dc/terms/bibliographicCitation> "Bei Jg. 28 setzt die durchgehende Nr.-Z\u00E4hlung ein" .
 <http://lobid.org/resource/ZDB6211-x> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/37043-5> .


### PR DESCRIPTION
See #541.

The about URIs are already created in the API with "primaryTopicOf"
added to them.
The triples of the about URIs generated in transformation
are discarded in API anyway, so the void:inDataset triple was never shown.
As to achieve daily updates we discard about URIs and provenance.
May be added later dynamically in the API. That's easy, because
the information to be added is of static nature.
- update tests
