### PR TITLE
Remove default `mysql.classifier` in pom.xml

### DIFF
--- a/lodmill-rd/pom.xml
+++ b/lodmill-rd/pom.xml
@@ -8,7 +8,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<target.jdk>1.6</target.jdk>
 		<junit.version>4.8.2</junit.version>
-		<mysql.classifier>linux-amd64</mysql.classifier>
 	</properties>
 	<repositories>
 		<repository>


### PR DESCRIPTION
Building by setting the variable with '-D' doesn't override
the default setting.
