### PR TITLE
Fix morph to have only one slash in the ID

### DIFF
--- a/lodmill-rd/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/lodmill-rd/src/main/resources/morph-hbz01-to-lobid.xml
@@ -109,7 +109,7 @@
 			<data source="@idzdb" name="a"/>
 			<data source="@id"/>
 		</combine>
-		<combine name="~rdf:subject" value="$[ns-lobid-resource]/${id}">
+		<combine name="~rdf:subject" value="$[ns-lobid-resource]${id}">
 			<data source="@idzdb"/>
 			<data source="@id" name="id"/>
 		</combine>

--- a/lodmill-rd/src/test/resources/hbz01.nt
+++ b/lodmill-rd/src/test/resources/hbz01.nt
@@ -1257,11 +1257,11 @@
 <http://lobid.org/resource/CT003012479> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-CT003012479> .
 <http://lobid.org/resource/CT003012479> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/CT003012479/about> .
 <http://lobid.org/resource/CT003012479> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DCT003012479> .
-<http://lobid.org/resource//HT000009600> <http://purl.org/dc/elements/1.1/publisher> "DAG" .
+<http://lobid.org/resource/HT000009600> <http://purl.org/dc/elements/1.1/publisher> "DAG" .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/bibliographicCitation> "Bei Jg. 28 setzt die durchgehende Nr.-Z\u00E4hlung ein" .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/37043-5> .
-<http://lobid.org/resource//HT000009600> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/37043-5> .
-<http://lobid.org/resource//HT000009600> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT006886476> .
+<http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/37043-5> .
+<http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT006886476> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT006886477> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT006886478> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT006886479> .
@@ -1269,11 +1269,11 @@
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT012299746> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/issued> "1948" .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/issued> "1948 - 1983" .
-<http://lobid.org/resource//HT000009600> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resource//HT000009600> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
+<http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
+<http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/subject> <http://dewey.info/class/330/> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/subject> <http://dewey.info/class/360/> .
-<http://lobid.org/resource//HT000009600> <http://purl.org/dc/terms/title> "Der Angestellte Hamburg" .
+<http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/title> "Der Angestellte Hamburg" .
 <http://lobid.org/resource/HT000009600> <http://purl.org/lobid/lv#hbzID> "HT000009600" .
 <http://lobid.org/resource/HT000009600> <http://purl.org/lobid/lv#zdbID> "6211-x" .
 <http://lobid.org/resource/HT000009600> <http://purl.org/ontology/bibo/issn> "0028-307x" .
@@ -1318,21 +1318,21 @@
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bo102:Zs%20371> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bo133:AMZ%20336> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bo133:Z%20848> .
-<http://lobid.org/resource//HT000009600> <http://rdvocab.info/Elements/otherTitleInformation> "Zeitschrift der Deutschen Angestellten-Gewerkschaft" .
-<http://lobid.org/resource//HT000009600> <http://rdvocab.info/Elements/placeOfPublication> "Hamburg" .
+<http://lobid.org/resource/HT000009600> <http://rdvocab.info/Elements/otherTitleInformation> "Zeitschrift der Deutschen Angestellten-Gewerkschaft" .
+<http://lobid.org/resource/HT000009600> <http://rdvocab.info/Elements/placeOfPublication> "Hamburg" .
 <http://lobid.org/resource/HT000009600> <http://rdvocab.info/Elements/publicationStatement> "Hamburg; DAG; 1948" .
-<http://lobid.org/resource//HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
+<http://lobid.org/resource/HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
-<http://lobid.org/resource//HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource//HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Journal> .
-<http://lobid.org/resource//HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
+<http://lobid.org/resource/HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
+<http://lobid.org/resource/HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Journal> .
+<http://lobid.org/resource/HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Manifestation> .
-<http://lobid.org/resource//HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Manifestation> .
+<http://lobid.org/resource/HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Manifestation> .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/6211-x> .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/2002/07/owl#sameAs> <http://lobid.org/resource/ZDB6211-x> .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/263589870> .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT000009600/about> .
-<http://lobid.org/resource//HT000009600> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT000009600> .
+<http://lobid.org/resource/HT000009600> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT000009600> .
 <http://lobid.org/resource/HT000290078> <http://iflastandards.info/ns/isbd/elements/P1053> "X, 99 S. : GRAPH. DARST." .
 <http://lobid.org/resource/HT000290078> <http://purl.org/dc/elements/1.1/publisher> "HOELDER-PICHLER-TEMPSKY" .
 <http://lobid.org/resource/HT000290078> <http://purl.org/dc/elements/1.1/publisher> "LEYKAM" .
@@ -1564,25 +1564,25 @@
 <http://lobid.org/resource/HT010662586> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT010662586> .
 <http://lobid.org/resource/HT010662586> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT010662586/about> .
 <http://lobid.org/resource/HT010662586> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT010662586> .
-<http://lobid.org/resource//HT010726584> <http://purl.org/dc/elements/1.1/publisher> "American Institute of Physics" .
-<http://lobid.org/resource//HT010726584> <http://purl.org/dc/terms/hasVersion> <http://www.bibliothek.uni-regensburg.de/ezeit/?1472746> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/dc/elements/1.1/publisher> "American Institute of Physics" .
+<http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/hasVersion> <http://www.bibliothek.uni-regensburg.de/ezeit/?1472746> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/issued> "1994 - " .
 <http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/issued> "1994" .
-<http://lobid.org/resource//HT010726584> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-<http://lobid.org/resource//HT010726584> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resource//HT010726584> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
-<http://lobid.org/resource//HT010726584> <http://purl.org/dc/terms/subject> <http://dewey.info/class/530/> .
-<http://lobid.org/resource//HT010726584> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4046259-6> .
-<http://lobid.org/resource//HT010726584> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4067488-5> .
-<http://lobid.org/resource//HT010726584> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4511937-5> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/subject> <http://dewey.info/class/530/> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4046259-6> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4067488-5> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4511937-5> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/title> "Physics of plasmas" .
-<http://lobid.org/resource//HT010726584> <http://purl.org/lobid/lv#fulltextOnline> <http://www.bibliothek.uni-regensburg.de/ezeit/?1472746> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#fulltextOnline> <http://www.bibliothek.uni-regensburg.de/ezeit/?1472746> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#hbzID> "HT010726584" .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectChain> "Periodikum | Zeitschriften | Computerdatei im Fernzugriff (Formschlagwort) | Online-Datenbank (Formschlagwort) | Online-Dokument | On-line-Datenbank (Formschlagwort) | On-line-Dokument | Online-Ressource | On-line-Publikation | Netzpublikation" .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectChain> "Plasmaphysik | Zeitschrift | Online-Publikation" .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#zdbID> "1472746-8" .
-<http://lobid.org/resource//HT010726584> <http://purl.org/ontology/bibo/issn> "1089-7674" .
-<http://lobid.org/resource//HT010726584> <http://purl.org/ontology/bibo/shortTitle> "PHPAEN" .
+<http://lobid.org/resource/HT010726584> <http://purl.org/ontology/bibo/issn> "1089-7674" .
+<http://lobid.org/resource/HT010726584> <http://purl.org/ontology/bibo/shortTitle> "PHPAEN" .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-1010:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-1044:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-107:> .
@@ -1616,21 +1616,21 @@
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-Due62:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-Kob7:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-Lan1:> .
-<http://lobid.org/resource//HT010726584> <http://rdvocab.info/Elements/otherTitleInformation> "devoted to original contributions to and reviews of the physics of plasmas, including magnetofluid mechanics, kinetic theory and statistical mechanics of fully and partially ionized gases" .
-<http://lobid.org/resource//HT010726584> <http://rdvocab.info/Elements/placeOfPublication> "[S.l.]" .
+<http://lobid.org/resource/HT010726584> <http://rdvocab.info/Elements/otherTitleInformation> "devoted to original contributions to and reviews of the physics of plasmas, including magnetofluid mechanics, kinetic theory and statistical mechanics of fully and partially ionized gases" .
+<http://lobid.org/resource/HT010726584> <http://rdvocab.info/Elements/placeOfPublication> "[S.l.]" .
 <http://lobid.org/resource/HT010726584> <http://rdvocab.info/Elements/publicationStatement> "[S.l.]; American Institute of Physics; 1994" .
-<http://lobid.org/resource//HT010726584> <http://rdvocab.info/Elements/statementOfResponsibility> "publ. by the American Institute of Physics" .
-<http://lobid.org/resource//HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
+<http://lobid.org/resource/HT010726584> <http://rdvocab.info/Elements/statementOfResponsibility> "publ. by the American Institute of Physics" .
+<http://lobid.org/resource/HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
-<http://lobid.org/resource//HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource//HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Journal> .
-<http://lobid.org/resource//HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
+<http://lobid.org/resource/HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
+<http://lobid.org/resource/HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Journal> .
+<http://lobid.org/resource/HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Manifestation> .
-<http://lobid.org/resource//HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Manifestation> .
+<http://lobid.org/resource/HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Manifestation> .
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/1472746-8> .
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/2002/07/owl#sameAs> <http://lobid.org/resource/ZDB1472746-8> .
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT010726584/about> .
-<http://lobid.org/resource//HT010726584> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT010726584> .
+<http://lobid.org/resource/HT010726584> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT010726584> .
 <http://lobid.org/resource/HT012299746> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT000009600> .
 <http://lobid.org/resource/HT012299746> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
 <http://lobid.org/resource/HT012926727> <http://iflastandards.info/ns/isbd/elements/P1053> "1 Kt.-Beil." .
@@ -1732,13 +1732,13 @@
 <http://lobid.org/resource/HT013077595> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013077595> .
 <http://lobid.org/resource/HT013077595> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT013077595/about> .
 <http://lobid.org/resource/HT013077595> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013077595> .
-<http://lobid.org/resource//HT013304490> <http://purl.org/dc/elements/1.1/publisher> "Ebner" .
+<http://lobid.org/resource/HT013304490> <http://purl.org/dc/elements/1.1/publisher> "Ebner" .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/bibliographicCitation> "viertelj\u00E4hrl." .
-<http://lobid.org/resource//HT013304490> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT013304885> .
+<http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT013304885> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/issued> "2002" .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/issued> "2002 - 2002" .
-<http://lobid.org/resource//HT013304490> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resource//HT013304490> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
+<http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
+<http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/subject> <http://dewey.info/class/050/> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/subject> <http://dewey.info/class/070/> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/subject> <http://dewey.info/class/620/> .
@@ -1752,25 +1752,25 @@
 <http://lobid.org/resource/HT013304490> <http://purl.org/lobid/lv#subjectChain> "Schmuck | Zeitschrift" .
 <http://lobid.org/resource/HT013304490> <http://purl.org/lobid/lv#zdbID> "2073588-1" .
 <http://lobid.org/resource/HT013304490> <http://purl.org/ontology/bibo/issn> "1618-7792" .
-<http://lobid.org/resource//HT013304490> <http://purl.org/ontology/bibo/oclcnum> "635743319" .
+<http://lobid.org/resource/HT013304490> <http://purl.org/ontology/bibo/oclcnum> "635743319" .
 <http://lobid.org/resource/HT013304490> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT013304490:DE-829:%3C%3C01%3E%3E%2034%20Z%2041> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT013304490:DE-Kn3:Zd%20Decide> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT013304490:DE-Tr5:> .
-<http://lobid.org/resource//HT013304490> <http://rdvocab.info/Elements/otherTitleInformation> "Magazin f\u00FCr Frauen, Kultur & Luxus" .
-<http://lobid.org/resource//HT013304490> <http://rdvocab.info/Elements/placeOfPublication> "Ulm" .
+<http://lobid.org/resource/HT013304490> <http://rdvocab.info/Elements/otherTitleInformation> "Magazin f\u00FCr Frauen, Kultur & Luxus" .
+<http://lobid.org/resource/HT013304490> <http://rdvocab.info/Elements/placeOfPublication> "Ulm" .
 <http://lobid.org/resource/HT013304490> <http://rdvocab.info/Elements/publicationStatement> "Ulm; Ebner; 2002" .
-<http://lobid.org/resource//HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
+<http://lobid.org/resource/HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resource/HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
-<http://lobid.org/resource//HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource//HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Journal> .
-<http://lobid.org/resource//HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
+<http://lobid.org/resource/HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
+<http://lobid.org/resource/HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Journal> .
+<http://lobid.org/resource/HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resource/HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Manifestation> .
-<http://lobid.org/resource//HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Manifestation> .
+<http://lobid.org/resource/HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Manifestation> .
 <http://lobid.org/resource/HT013304490> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2073588-1> .
 <http://lobid.org/resource/HT013304490> <http://www.w3.org/2002/07/owl#sameAs> <http://lobid.org/resource/ZDB2073588-1> .
-<http://lobid.org/resource//HT013304490> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/635743319> .
+<http://lobid.org/resource/HT013304490> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/635743319> .
 <http://lobid.org/resource/HT013304490> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT013304490/about> .
-<http://lobid.org/resource//HT013304490> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013304490> .
+<http://lobid.org/resource/HT013304490> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013304490> .
 <http://lobid.org/resource/HT013304885> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT013304490> .
 <http://lobid.org/resource/HT013304885> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
 <http://lobid.org/resource/HT013370531> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT015865114> .


### PR DESCRIPTION
Affected are all resources which are also ZDB resources.

See #605.
- update tests
