### PR TITLE
Make "install-dependencies.sh" reusable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk: oraclejdk7
 before_install:
   - cd lodmill-rd; sh install-dependencies.sh; cd ..
+  - sudo apt-get install libaio-dev
 install:
   - mvn clean install -e -q -DskipTests=true -Dmysql.classifier=linux-amd64 --settings settings.xml
 script:

--- a/lodmill-rd/install-dependencies.sh
+++ b/lodmill-rd/install-dependencies.sh
@@ -2,10 +2,10 @@
 cd ../..
 git clone git://github.com/culturegraph/metafacture-core.git metafacture-core-dependency
 cd metafacture-core-dependency
+git pull
 mvn clean install -DskipTests=true
 cd ..
 git clone https://github.com/hbz/metafacture-core.git
 cd metafacture-core
+git pull
 mvn clean install -DskipTests=true
-sudo apt-get install libaio-dev
-


### PR DESCRIPTION
- move a "sudo" command to travis installation script
- add some "git pull" in the case the repo couldn't be cloned as it exists already

This makes "install-dependencies.sh" reusable by other building
processes , e.g. when deploying to a server.
