### PR TITLE
Check if the same ES alias already exists

### DIFF
--- a/lodmill-ld/src/main/java/org/lobid/lodmill/hadoop/NTriplesToJsonLd.java
+++ b/lodmill-ld/src/main/java/org/lobid/lodmill/hadoop/NTriplesToJsonLd.java
@@ -201,7 +201,8 @@ public class NTriplesToJsonLd implements Tool {
 			final String newAlias = prefix + suffix;
 			LOG.info(format("Prefix '%s', newest index: %s", prefix, newIndex));
 			removeOldAliases(indicesForPrefix, newAlias);
-			createNewAlias(newIndex, newAlias);
+			if (!newIndex.equals(indicesForPrefix))
+				createNewAlias(newIndex, newAlias);
 			deleteOldIndices(name, indicesForPrefix);
 		}
 	}


### PR DESCRIPTION
This avoids a possible InvalidAliasNameException, which is
thrown whenever  an index exists with the same name as the alias.