### PR TITLE
Issue 573 incremental es updates

### DIFF
--- a/lodmill-ld/doc/scripts/processResources.sh
+++ b/lodmill-ld/doc/scripts/processResources.sh
@@ -13,9 +13,6 @@ SET=$2
 TIME=`date '+%Y%m%d-%H%M%S'`
 
 INDEX_NAME=lobid-resources-$TIME
-if [ $SET = "Updates" ]; then
-        INDEX_NAME=$ALIAS
-fi
 
 HDFS_FILE="hbzlod/lobid-resources-$SET/resources-dump.nt"
 echo "Dumping to $HDFS_FILE ..."


### PR DESCRIPTION
Enable to update an index instead of building a new one completely whenever some new docs appear. See #573.