### PR TITLE
Add switch to only update index alias if no test is indexed

### DIFF
--- a/lodmill-ld/src/main/java/org/lobid/lodmill/hadoop/NTriplesToJsonLd.java
+++ b/lodmill-ld/src/main/java/org/lobid/lodmill/hadoop/NTriplesToJsonLd.java
@@ -154,7 +154,8 @@ public class NTriplesToJsonLd implements Tool {
 		LOG.info(String.format("Process: index %s, type %s", indexName, indexType));
 		boolean success = job.waitForCompletion(true);
 		if (success) {
-			if (!aliasSuffix.equals("NOALIAS") || !update)
+			if (!aliasSuffix.equals("NOALIAS") || !update
+					|| !aliasSuffix.toLowerCase().contains("test"))
 				updateAliases(indexName, aliasSuffix);
 			client.admin().indices().prepareRefresh(indexName).execute().actionGet();
 			setIndexRefreshInterval(CLIENT, "1000");


### PR DESCRIPTION
See #643.

Indexing e.g. > 3 test sets will cause to update all the aliases (even
the productive one) to be updated, that is to be transferred to newer indices.
If these newer index is just a small test one - bad luck.
This simple switch will provide index alias update if the test sets
are indexed - at least if their aliases contain "test". Which is the
cause in our workflow.
There are sensibler ways, e.g. allowance to update an alias only if the
to be set alias equals the old alias.