### PR TITLE
Adjust mapping of supplements

### DIFF
--- a/lodmill-rd/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/lodmill-rd/src/main/resources/morph-hbz01-to-lobid.xml
@@ -59,16 +59,22 @@
 		<!-- ####### Child, link to parent and vice versa, e.g. HT000009600 -->
 		<!-- ####################### -->
 		<data source="4[56789]3[-abr][-12].a" name="@idTitleSeries"/>
-		<data source="010-1.a|529z1.9|@idTitleSeries" name="@isPartOfHbzId"/>
+		<data source="529z1.9" name="@hasSupplement"/>
+		<data source="010-1.a|@idTitleSeries" name="@isPartOfHbzId"/>
 		<!-- temporarily set new subject uri -->
 		<data name="~rdf:subject" source="010-1.a|529z1.9|@idTitleSeries">
 			<regexp match="(.*)" format="$[ns-lobid-resource]${1}"/>
 		</data>
 		<combine name="http://purl.org/dc/terms/hasPart" value="$[ns-lobid-resource]${subjectid}">
-			<data source="010-1.a|529z1.9|@idTitleSeries" name=""/>
+			<data source="010-1.a|@idTitleSeries"/>
 			<data source="@id" name="subjectid"/>
 		</combine>
-		<data source="010-1.a|529z1.9|@idTitleSeries" name="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">
+		<!-- is supplement to -->
+		<combine name="http://rdaregistry.info/Elements/u/P60259" value="$[ns-lobid-resource]${subjectid}">
+			<data source="529z1.9"/>
+			<data source="@id" name="subjectid"/>
+		</combine>
+		<data source="010-1.a|@idTitleSeries" name="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">
 			<regexp match=".*" format="http://purl.org/ontology/bibo/Collection"/>
 		</data>
 		<!-- set subject uri of resource anew -->
@@ -1138,6 +1144,9 @@
 			</if>
 			<data source="523[-a][-1].a" name="a"/>
 		</combine>
+		<data source="@hasSupplement" name="http://rdaregistry.info/Elements/u/P60281">
+			<regexp match="(.*)" format="$[ns-lobid-resource]${1}"/>
+		</data>
 		<data source="599[-b][-1].[a]" name="@isPartOfHbzId"/>
 		<data source="@isPartOfHbzId" name="http://purl.org/dc/terms/isPartOf">
 			<regexp match="(.*)" format="$[ns-lobid-resource]${1}"/>

--- a/lodmill-rd/src/test/resources/hbz01.nt
+++ b/lodmill-rd/src/test/resources/hbz01.nt
@@ -1252,12 +1252,6 @@
 <http://lobid.org/resource/CT003012479> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DCT003012479> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/elements/1.1/publisher> "DAG" .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/37043-5> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT006886476> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT006886477> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT006886478> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT006886479> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT007527436> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT012299746> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/issued> "1948" .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/issued> "1948 - 1983" .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -1309,6 +1303,12 @@
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bo102:Zs%20371> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bo133:AMZ%20336> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bo133:Z%20848> .
+<http://lobid.org/resource/HT000009600> <http://rdaregistry.info/Elements/u/P60281> <http://lobid.org/resource/HT006886476> .
+<http://lobid.org/resource/HT000009600> <http://rdaregistry.info/Elements/u/P60281> <http://lobid.org/resource/HT006886477> .
+<http://lobid.org/resource/HT000009600> <http://rdaregistry.info/Elements/u/P60281> <http://lobid.org/resource/HT006886478> .
+<http://lobid.org/resource/HT000009600> <http://rdaregistry.info/Elements/u/P60281> <http://lobid.org/resource/HT006886479> .
+<http://lobid.org/resource/HT000009600> <http://rdaregistry.info/Elements/u/P60281> <http://lobid.org/resource/HT007527436> .
+<http://lobid.org/resource/HT000009600> <http://rdaregistry.info/Elements/u/P60281> <http://lobid.org/resource/HT012299746> .
 <http://lobid.org/resource/HT000009600> <http://rdvocab.info/Elements/frequency> "Bei Jg. 28 setzt die durchgehende Nr.-Z\u00E4hlung ein" .
 <http://lobid.org/resource/HT000009600> <http://rdvocab.info/Elements/otherTitleInformation> "Zeitschrift der Deutschen Angestellten-Gewerkschaft" .
 <http://lobid.org/resource/HT000009600> <http://rdvocab.info/Elements/placeOfPublication> "Hamburg" .
@@ -1500,16 +1500,11 @@
 <http://lobid.org/resource/HT006266886> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006266886> .
 <http://lobid.org/resource/HT006266886> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT006266886/about> .
 <http://lobid.org/resource/HT006266886> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT006266886> .
-<http://lobid.org/resource/HT006886476> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT000009600> .
-<http://lobid.org/resource/HT006886476> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/HT006886477> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT000009600> .
-<http://lobid.org/resource/HT006886477> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/HT006886478> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT000009600> .
-<http://lobid.org/resource/HT006886478> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/HT006886479> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT000009600> .
-<http://lobid.org/resource/HT006886479> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
-<http://lobid.org/resource/HT007527436> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT000009600> .
-<http://lobid.org/resource/HT007527436> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
+<http://lobid.org/resource/HT006886476> <http://rdaregistry.info/Elements/u/P60259> <http://lobid.org/resource/HT000009600> .
+<http://lobid.org/resource/HT006886477> <http://rdaregistry.info/Elements/u/P60259> <http://lobid.org/resource/HT000009600> .
+<http://lobid.org/resource/HT006886478> <http://rdaregistry.info/Elements/u/P60259> <http://lobid.org/resource/HT000009600> .
+<http://lobid.org/resource/HT006886479> <http://rdaregistry.info/Elements/u/P60259> <http://lobid.org/resource/HT000009600> .
+<http://lobid.org/resource/HT007527436> <http://rdaregistry.info/Elements/u/P60259> <http://lobid.org/resource/HT000009600> .
 <http://lobid.org/resource/HT009719670> <http://purl.org/dc/elements/1.1/publisher> "Hatier/Didier" .
 <http://lobid.org/resource/HT009719670> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/11860225X> .
 <http://lobid.org/resource/HT009719670> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/133991210> .
@@ -1613,8 +1608,7 @@
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/2002/07/owl#sameAs> <http://lobid.org/resource/ZDB1472746-8> .
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT010726584/about> .
 <http://lobid.org/resource/HT010726584> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT010726584> .
-<http://lobid.org/resource/HT012299746> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT000009600> .
-<http://lobid.org/resource/HT012299746> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
+<http://lobid.org/resource/HT012299746> <http://rdaregistry.info/Elements/u/P60259> <http://lobid.org/resource/HT000009600> .
 <http://lobid.org/resource/HT012926727> <http://iflastandards.info/ns/isbd/elements/P1053> "XIV, 514 S. : graph. Darst., Kt." .
 <http://lobid.org/resource/HT012926727> <http://purl.org/dc/elements/1.1/publisher> "Springer" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/dc/terms/creator> <http://d-nb.info/gnd/1031919368> .
@@ -1714,7 +1708,6 @@
 <http://lobid.org/resource/HT013077595> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT013077595/about> .
 <http://lobid.org/resource/HT013077595> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013077595> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/elements/1.1/publisher> "Ebner" .
-<http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resource/HT013304885> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/issued> "2002" .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/issued> "2002 - 2002" .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -1735,6 +1728,7 @@
 <http://lobid.org/resource/HT013304490> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT013304490:DE-829:%3C%3C01%3E%3E%2034%20Z%2041> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT013304490:DE-Kn3:Zd%20Decide> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT013304490:DE-Tr5:> .
+<http://lobid.org/resource/HT013304490> <http://rdaregistry.info/Elements/u/P60281> <http://lobid.org/resource/HT013304885> .
 <http://lobid.org/resource/HT013304490> <http://rdvocab.info/Elements/frequency> "Periodizit\u00E4t: viertelj\u00E4hrl." .
 <http://lobid.org/resource/HT013304490> <http://rdvocab.info/Elements/otherTitleInformation> "Magazin f\u00FCr Frauen, Kultur & Luxus" .
 <http://lobid.org/resource/HT013304490> <http://rdvocab.info/Elements/placeOfPublication> "Ulm" .
@@ -1750,8 +1744,7 @@
 <http://lobid.org/resource/HT013304490> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/635743319> .
 <http://lobid.org/resource/HT013304490> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT013304490/about> .
 <http://lobid.org/resource/HT013304490> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013304490> .
-<http://lobid.org/resource/HT013304885> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT013304490> .
-<http://lobid.org/resource/HT013304885> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
+<http://lobid.org/resource/HT013304885> <http://rdaregistry.info/Elements/u/P60259> <http://lobid.org/resource/HT013304490> .
 <http://lobid.org/resource/HT013370531> <http://purl.org/dc/terms/hasPart> <http://lobid.org/resource/HT015865114> .
 <http://lobid.org/resource/HT013370531> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Collection> .
 <http://lobid.org/resource/HT013577568> <http://purl.org/dc/terms/bibliographicCitation> "Kontinuit\u00E4t und Diskontinuit\u00E4t / hrsg. von Thomas Gr\u00FCnewald ... - Berlin [u.a.], 2003. - (Reallexikon der germanischen Altertumskunde : Erg\u00E4nzungsb\u00E4nde ; 35). - S. [266]-344 : Ill., Kt." .


### PR DESCRIPTION
See hbz/lobid#102..

* adjust test

IsPart and hasPart was mixed up is fixed now. Also, a better property
is used indicating not only a relation but the supplemental type of relation.