### PR TITLE
Fix bug in "checking if the same ES alias already exists"

### DIFF
--- a/lodmill-ld/src/main/java/org/lobid/lodmill/hadoop/NTriplesToJsonLd.java
+++ b/lodmill-ld/src/main/java/org/lobid/lodmill/hadoop/NTriplesToJsonLd.java
@@ -219,7 +219,7 @@ public class NTriplesToJsonLd implements Tool {
 			final String newAlias = prefix + suffix;
 			LOG.info(format("Prefix '%s', newest index: %s", prefix, newIndex));
 			removeOldAliases(indicesForPrefix, newAlias);
-			if (!newIndex.equals(indicesForPrefix))
+			if (!name.equals(newAlias))
 				createNewAlias(newIndex, newAlias);
 			deleteOldIndices(name, indicesForPrefix);
 		}


### PR DESCRIPTION
Fixed wrong literal for comparison.

See bdd56f1ecc840b1038214a0d248792c059267875.