### PR TITLE
Remove additional Misc typing for journals & series.

### DIFF
--- a/lodmill-rd/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/lodmill-rd/src/main/resources/morph-hbz01-to-lobid.xml
@@ -194,7 +194,6 @@
 		<!-- ####################### -->
 		<!-- type is book (and also manifestation) if 050 begins with 'a' and 051 or 052 is missing 
 			or 051 and 052 does not fulfill a certain pattern -->
-		<data source="051." name="@type"/>
 		<combine name="@rdftype" value="http://purl.org/ontology/bibo/Book">
 			<if>
 				<none>
@@ -467,6 +466,7 @@
 			<if>
 				<none>
 					<data source="@rdftype"/>
+					<data source="@typeOnly"/>
 				</none>
 			</if>
 			<data source="@id"/>

--- a/lodmill-rd/src/test/resources/hbz01.nt
+++ b/lodmill-rd/src/test/resources/hbz01.nt
@@ -1,32 +1,32 @@
+<http://d-nb.info/gnd/10048424-4> <http://d-nb.info/standards/elementset/gnd#preferredName> "Landesbetrieb Stra\u00DFen und Verkehr Rheinland-Pfalz <Koblenz>" .
 <http://d-nb.info/gnd/10048424-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody> "Landesbetrieb Stra\u00DFen und Verkehr Rheinland-Pfalz <Koblenz>" .
 <http://d-nb.info/gnd/10048424-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Landesbetrieb Stra\u00DFen und Verkehr Rheinland-Pfalz <Koblenz>" .
-<http://d-nb.info/gnd/10048424-4> <http://d-nb.info/standards/elementset/gnd#preferredName> "Landesbetrieb Stra\u00DFen und Verkehr Rheinland-Pfalz <Koblenz>" .
-<http://d-nb.info/gnd/1023391147> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Maes, Sientje" .
 <http://d-nb.info/gnd/1023391147> <http://d-nb.info/standards/elementset/gnd#preferredName> "Maes, Sientje" .
-<http://d-nb.info/gnd/1031919368> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "M\u00FCller, Leonhard, 1929-" .
+<http://d-nb.info/gnd/1023391147> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Maes, Sientje" .
 <http://d-nb.info/gnd/1031919368> <http://d-nb.info/standards/elementset/gnd#preferredName> "M\u00FCller, Leonhard, 1929-" .
-<http://d-nb.info/gnd/105667129> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Weber, J\u00FCrgen" .
+<http://d-nb.info/gnd/1031919368> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "M\u00FCller, Leonhard, 1929-" .
 <http://d-nb.info/gnd/105667129> <http://d-nb.info/standards/elementset/gnd#preferredName> "Weber, J\u00FCrgen" .
-<http://d-nb.info/gnd/105745944> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Schmidt, Eckhard" .
+<http://d-nb.info/gnd/105667129> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Weber, J\u00FCrgen" .
 <http://d-nb.info/gnd/105745944> <http://d-nb.info/standards/elementset/gnd#preferredName> "Schmidt, Eckhard" .
-<http://d-nb.info/gnd/108092704> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Heinrichs, Johannes" .
+<http://d-nb.info/gnd/105745944> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Schmidt, Eckhard" .
 <http://d-nb.info/gnd/108092704> <http://d-nb.info/standards/elementset/gnd#preferredName> "Heinrichs, Johannes" .
+<http://d-nb.info/gnd/108092704> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Heinrichs, Johannes" .
 <http://d-nb.info/gnd/10880724X> <http://d-nb.info/standards/elementset/gnd#preferredName> "Altekamp, Heinrich" .
 <http://d-nb.info/gnd/10880724X> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Altekamp, Heinrich" .
 <http://d-nb.info/gnd/109490312> <http://d-nb.info/standards/elementset/gnd#preferredName> "Boer, Hans-Peter, 1949-" .
 <http://d-nb.info/gnd/109490312> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Boer, Hans-Peter, 1949-" .
-<http://d-nb.info/gnd/109702662> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Mensing, Hans Peter, 1942-" .
 <http://d-nb.info/gnd/109702662> <http://d-nb.info/standards/elementset/gnd#preferredName> "Mensing, Hans Peter, 1942-" .
+<http://d-nb.info/gnd/109702662> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Mensing, Hans Peter, 1942-" .
 <http://d-nb.info/gnd/11075851X> <http://d-nb.info/standards/elementset/gnd#preferredName> "Conrad, Christoph" .
 <http://d-nb.info/gnd/11075851X> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Conrad, Christoph" .
 <http://d-nb.info/gnd/11079267X> <http://d-nb.info/standards/elementset/gnd#preferredName> "Balke, Kirsten" .
 <http://d-nb.info/gnd/11079267X> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Balke, Kirsten" .
-<http://d-nb.info/gnd/115541802> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Maimbourg, Louis, 1610-1686" .
 <http://d-nb.info/gnd/115541802> <http://d-nb.info/standards/elementset/gnd#preferredName> "Maimbourg, Louis, 1610-1686" .
-<http://d-nb.info/gnd/116620153> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Giesecke, Carl Ludwig <<von>>, 1761-1833" .
+<http://d-nb.info/gnd/115541802> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Maimbourg, Louis, 1610-1686" .
 <http://d-nb.info/gnd/116620153> <http://d-nb.info/standards/elementset/gnd#preferredName> "Giesecke, Carl Ludwig <<von>>, 1761-1833" .
-<http://d-nb.info/gnd/118033948> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Meier, Elmar" .
+<http://d-nb.info/gnd/116620153> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Giesecke, Carl Ludwig <<von>>, 1761-1833" .
 <http://d-nb.info/gnd/118033948> <http://d-nb.info/standards/elementset/gnd#preferredName> "Meier, Elmar" .
+<http://d-nb.info/gnd/118033948> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Meier, Elmar" .
 <http://d-nb.info/gnd/118500546> <http://d-nb.info/standards/elementset/gnd#preferredName> "Adam, Theo, 1926-" .
 <http://d-nb.info/gnd/118500546> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Adam, Theo, 1926-" .
 <http://d-nb.info/gnd/11850066X> <http://d-nb.info/standards/elementset/gnd#preferredName> "Adenauer, Konrad, 1876-1967" .
@@ -41,103 +41,103 @@
 <http://d-nb.info/gnd/118524186> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Debussy, Claude, 1862-1918" .
 <http://d-nb.info/gnd/118533592> <http://d-nb.info/standards/elementset/gnd#preferredName> "Fitzgerald, Francis Scott, 1896-1940" .
 <http://d-nb.info/gnd/118533592> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Fitzgerald, Francis Scott, 1896-1940" .
-<http://d-nb.info/gnd/118535765> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Friedrich, II., Heiliges R\u00F6misches Reich, Kaiser, 1194-1250" .
 <http://d-nb.info/gnd/118535765> <http://d-nb.info/standards/elementset/gnd#preferredName> "Friedrich, II., Heiliges R\u00F6misches Reich, Kaiser, 1194-1250" .
-<http://d-nb.info/gnd/118551655> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Hitler, Adolf, 1889-1945" .
+<http://d-nb.info/gnd/118535765> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Friedrich, II., Heiliges R\u00F6misches Reich, Kaiser, 1194-1250" .
 <http://d-nb.info/gnd/118551655> <http://d-nb.info/standards/elementset/gnd#preferredName> "Hitler, Adolf, 1889-1945" .
+<http://d-nb.info/gnd/118551655> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Hitler, Adolf, 1889-1945" .
 <http://d-nb.info/gnd/118560034> <http://d-nb.info/standards/elementset/gnd#preferredName> "Karl, I., Heiliges R\u00F6misches Reich, Kaiser, 747-814" .
-<http://d-nb.info/gnd/118577018> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Manfredi, Sicilia, Re, 1232-1266" .
 <http://d-nb.info/gnd/118577018> <http://d-nb.info/standards/elementset/gnd#preferredName> "Manfredi, Sicilia, Re, 1232-1266" .
+<http://d-nb.info/gnd/118577018> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Manfredi, Sicilia, Re, 1232-1266" .
 <http://d-nb.info/gnd/118595881> <http://d-nb.info/standards/elementset/gnd#preferredName> "Porsche, Ferdinand, 1875-1951" .
-<http://d-nb.info/gnd/11860225X> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Rohmer, Eric, 1920-2010" .
 <http://d-nb.info/gnd/11860225X> <http://d-nb.info/standards/elementset/gnd#preferredName> "Rohmer, Eric, 1920-2010" .
-<http://d-nb.info/gnd/118610724> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Schreier, Peter, 1935-" .
+<http://d-nb.info/gnd/11860225X> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Rohmer, Eric, 1920-2010" .
 <http://d-nb.info/gnd/118610724> <http://d-nb.info/standards/elementset/gnd#preferredName> "Schreier, Peter, 1935-" .
+<http://d-nb.info/gnd/118610724> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Schreier, Peter, 1935-" .
 <http://d-nb.info/gnd/118637649> <http://d-nb.info/standards/elementset/gnd#preferredName> "Albertus, Magnus, 1193-1280" .
 <http://d-nb.info/gnd/118637649> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Albertus, Magnus, 1193-1280" .
 <http://d-nb.info/gnd/118657496> <http://d-nb.info/standards/elementset/gnd#preferredName> "Bassani, Giorgio, 1916-2000" .
 <http://d-nb.info/gnd/118657496> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Bassani, Giorgio, 1916-2000" .
 <http://d-nb.info/gnd/118677942> <http://d-nb.info/standards/elementset/gnd#preferredName> "De Sica, Vittorio, 1901-1974" .
 <http://d-nb.info/gnd/118677942> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "De Sica, Vittorio, 1901-1974" .
-<http://d-nb.info/gnd/118839055> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Wedgwood, Cicely V., 1910-1997" .
 <http://d-nb.info/gnd/118839055> <http://d-nb.info/standards/elementset/gnd#preferredName> "Wedgwood, Cicely V., 1910-1997" .
-<http://d-nb.info/gnd/118867539> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Rotzsch, Hans-Joachim, 1929-2013" .
+<http://d-nb.info/gnd/118839055> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Wedgwood, Cicely V., 1910-1997" .
 <http://d-nb.info/gnd/118867539> <http://d-nb.info/standards/elementset/gnd#preferredName> "Rotzsch, Hans-Joachim, 1929-2013" .
-<http://d-nb.info/gnd/119055716> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Winter, Peter <<von>>, 1754-1825" .
+<http://d-nb.info/gnd/118867539> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Rotzsch, Hans-Joachim, 1929-2013" .
 <http://d-nb.info/gnd/119055716> <http://d-nb.info/standards/elementset/gnd#preferredName> "Winter, Peter <<von>>, 1754-1825" .
+<http://d-nb.info/gnd/119055716> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Winter, Peter <<von>>, 1754-1825" .
 <http://d-nb.info/gnd/119080389> <http://d-nb.info/standards/elementset/gnd#preferredName> "Banville, Th\u00E9odore <<de>>, 1823-1891" .
 <http://d-nb.info/gnd/119080389> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Banville, Th\u00E9odore <<de>>, 1823-1891" .
 <http://d-nb.info/gnd/119468476> <http://d-nb.info/standards/elementset/gnd#preferredName> "Bruccoli, Matthew Joseph, 1931-" .
 <http://d-nb.info/gnd/119468476> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Bruccoli, Matthew Joseph, 1931-" .
 <http://d-nb.info/gnd/120454874> <http://d-nb.info/standards/elementset/gnd#preferredName> "Berger, Helmut, 1944-" .
 <http://d-nb.info/gnd/120454874> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Berger, Helmut, 1944-" .
-<http://d-nb.info/gnd/121815684> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "L\u00FCken, Sven" .
 <http://d-nb.info/gnd/121815684> <http://d-nb.info/standards/elementset/gnd#preferredName> "L\u00FCken, Sven" .
+<http://d-nb.info/gnd/121815684> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "L\u00FCken, Sven" .
 <http://d-nb.info/gnd/121842118> <http://d-nb.info/standards/elementset/gnd#preferredName> "Clev, Hans-G\u00FCnther, 1961-" .
 <http://d-nb.info/gnd/121842118> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Clev, Hans-G\u00FCnther, 1961-" .
-<http://d-nb.info/gnd/122021878> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Werthes, Sascha" .
 <http://d-nb.info/gnd/122021878> <http://d-nb.info/standards/elementset/gnd#preferredName> "Werthes, Sascha" .
-<http://d-nb.info/gnd/123633206> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Pepoli, Alessandro Ercole, 1757-1796" .
+<http://d-nb.info/gnd/122021878> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Werthes, Sascha" .
 <http://d-nb.info/gnd/123633206> <http://d-nb.info/standards/elementset/gnd#preferredName> "Pepoli, Alessandro Ercole, 1757-1796" .
+<http://d-nb.info/gnd/123633206> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Pepoli, Alessandro Ercole, 1757-1796" .
 <http://d-nb.info/gnd/124348165> <http://d-nb.info/standards/elementset/gnd#preferredName> "Engelhardt, Manfred, 1924-" .
 <http://d-nb.info/gnd/124348165> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Engelhardt, Manfred, 1924-" .
 <http://d-nb.info/gnd/124362869> <http://d-nb.info/standards/elementset/gnd#preferredName> "Baldwin, Dalton, 1931-" .
 <http://d-nb.info/gnd/124362869> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Baldwin, Dalton, 1931-" .
-<http://d-nb.info/gnd/124515312> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Ippoldt, Juliusz, 1867-1960" .
 <http://d-nb.info/gnd/124515312> <http://d-nb.info/standards/elementset/gnd#preferredName> "Ippoldt, Juliusz, 1867-1960" .
-<http://d-nb.info/gnd/124897274> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Pfundner, Martin, 1930-" .
+<http://d-nb.info/gnd/124515312> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Ippoldt, Juliusz, 1867-1960" .
 <http://d-nb.info/gnd/124897274> <http://d-nb.info/standards/elementset/gnd#preferredName> "Pfundner, Martin, 1930-" .
+<http://d-nb.info/gnd/124897274> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Pfundner, Martin, 1930-" .
+<http://d-nb.info/gnd/128755-2> <http://d-nb.info/standards/elementset/gnd#preferredName> "Kreisheimatverein <Coesfeld>" .
 <http://d-nb.info/gnd/128755-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody> "Kreisheimatverein <Coesfeld>" .
 <http://d-nb.info/gnd/128755-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Kreisheimatverein <Coesfeld>" .
-<http://d-nb.info/gnd/128755-2> <http://d-nb.info/standards/elementset/gnd#preferredName> "Kreisheimatverein <Coesfeld>" .
-<http://d-nb.info/gnd/128992204> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Wenkel, Ortrun, 1942-" .
 <http://d-nb.info/gnd/128992204> <http://d-nb.info/standards/elementset/gnd#preferredName> "Wenkel, Ortrun, 1942-" .
+<http://d-nb.info/gnd/128992204> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Wenkel, Ortrun, 1942-" .
 <http://d-nb.info/gnd/129016713> <http://d-nb.info/standards/elementset/gnd#preferredName> "Fehrmann, Gisela" .
 <http://d-nb.info/gnd/129016713> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Fehrmann, Gisela" .
 <http://d-nb.info/gnd/129389641> <http://d-nb.info/standards/elementset/gnd#preferredName> "Aug\u00E9r, Arleen, 1939-1993" .
 <http://d-nb.info/gnd/129389641> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Aug\u00E9r, Arleen, 1939-1993" .
-<http://d-nb.info/gnd/130290637> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Mespl\u00E9, Mady, 1931-" .
 <http://d-nb.info/gnd/130290637> <http://d-nb.info/standards/elementset/gnd#preferredName> "Mespl\u00E9, Mady, 1931-" .
-<http://d-nb.info/gnd/133595935> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Reinarz, Titus, 1948-" .
+<http://d-nb.info/gnd/130290637> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Mespl\u00E9, Mady, 1931-" .
 <http://d-nb.info/gnd/133595935> <http://d-nb.info/standards/elementset/gnd#preferredName> "Reinarz, Titus, 1948-" .
-<http://d-nb.info/gnd/133991210> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Salins, Genevi\u00E8ve-Dominique <<de>>" .
+<http://d-nb.info/gnd/133595935> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Reinarz, Titus, 1948-" .
 <http://d-nb.info/gnd/133991210> <http://d-nb.info/standards/elementset/gnd#preferredName> "Salins, Genevi\u00E8ve-Dominique <<de>>" .
-<http://d-nb.info/gnd/134769236> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Martineau, Malcolm, 1960-" .
+<http://d-nb.info/gnd/133991210> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Salins, Genevi\u00E8ve-Dominique <<de>>" .
 <http://d-nb.info/gnd/134769236> <http://d-nb.info/standards/elementset/gnd#preferredName> "Martineau, Malcolm, 1960-" .
-<http://d-nb.info/gnd/134782852> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "MacDougall, Jamie, 1966-" .
+<http://d-nb.info/gnd/134769236> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Martineau, Malcolm, 1960-" .
 <http://d-nb.info/gnd/134782852> <http://d-nb.info/standards/elementset/gnd#preferredName> "MacDougall, Jamie, 1966-" .
+<http://d-nb.info/gnd/134782852> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "MacDougall, Jamie, 1966-" .
 <http://d-nb.info/gnd/13482167X> <http://d-nb.info/standards/elementset/gnd#preferredName> "Anderson, Lorna, 1962-" .
 <http://d-nb.info/gnd/13482167X> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Anderson, Lorna, 1962-" .
-<http://d-nb.info/gnd/134845323> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Lewis, Bryn" .
 <http://d-nb.info/gnd/134845323> <http://d-nb.info/standards/elementset/gnd#preferredName> "Lewis, Bryn" .
-<http://d-nb.info/gnd/134926277> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Ogden, Craig" .
+<http://d-nb.info/gnd/134845323> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Lewis, Bryn" .
 <http://d-nb.info/gnd/134926277> <http://d-nb.info/standards/elementset/gnd#preferredName> "Ogden, Craig" .
-<http://d-nb.info/gnd/134926285> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Nathan, Regina" .
+<http://d-nb.info/gnd/134926277> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Ogden, Craig" .
 <http://d-nb.info/gnd/134926285> <http://d-nb.info/standards/elementset/gnd#preferredName> "Nathan, Regina" .
-<http://d-nb.info/gnd/136788548> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "J\u00E4ger, Ludwig, 1943-" .
+<http://d-nb.info/gnd/134926285> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Nathan, Regina" .
 <http://d-nb.info/gnd/136788548> <http://d-nb.info/standards/elementset/gnd#preferredName> "J\u00E4ger, Ludwig, 1943-" .
-<http://d-nb.info/gnd/137082479> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Mayr, Alois, 1938-" .
+<http://d-nb.info/gnd/136788548> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "J\u00E4ger, Ludwig, 1943-" .
 <http://d-nb.info/gnd/137082479> <http://d-nb.info/standards/elementset/gnd#preferredName> "Mayr, Alois, 1938-" .
+<http://d-nb.info/gnd/137082479> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Mayr, Alois, 1938-" .
 <http://d-nb.info/gnd/141618302> <http://d-nb.info/standards/elementset/gnd#preferredName> "Capolicchio, Lino, 1943-" .
 <http://d-nb.info/gnd/141618302> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Capolicchio, Lino, 1943-" .
-<http://d-nb.info/gnd/141649429> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Testi, Fabio, 1941-" .
 <http://d-nb.info/gnd/141649429> <http://d-nb.info/standards/elementset/gnd#preferredName> "Testi, Fabio, 1941-" .
+<http://d-nb.info/gnd/141649429> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Testi, Fabio, 1941-" .
 <http://d-nb.info/gnd/141834919> <http://d-nb.info/standards/elementset/gnd#preferredName> "Dardenne, ..." .
 <http://d-nb.info/gnd/141834919> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Dardenne, ..." .
-<http://d-nb.info/gnd/141889810> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Krug, ..." .
 <http://d-nb.info/gnd/141889810> <http://d-nb.info/standards/elementset/gnd#preferredName> "Krug, ..." .
+<http://d-nb.info/gnd/141889810> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Krug, ..." .
 <http://d-nb.info/gnd/141891173> <http://d-nb.info/standards/elementset/gnd#preferredName> "B\u00F6hm, Johann, der J\u00FCngere" .
 <http://d-nb.info/gnd/141891173> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "B\u00F6hm, Johann, der J\u00FCngere" .
 <http://d-nb.info/gnd/141927135> <http://d-nb.info/standards/elementset/gnd#preferredName> "Bilau, Margarete, 1768-" .
 <http://d-nb.info/gnd/141927135> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Bilau, Margarete, 1768-" .
-<http://d-nb.info/gnd/142027901> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Fuchs, ..." .
 <http://d-nb.info/gnd/142027901> <http://d-nb.info/standards/elementset/gnd#preferredName> "Fuchs, ..." .
+<http://d-nb.info/gnd/142027901> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Fuchs, ..." .
 <http://d-nb.info/gnd/142061166> <http://d-nb.info/standards/elementset/gnd#preferredName> "Annoni, ..." .
 <http://d-nb.info/gnd/142061166> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Annoni, ..." .
 <http://d-nb.info/gnd/14216075X> <http://d-nb.info/standards/elementset/gnd#preferredName> "Bilau, Wilhelmine, 1787-1805" .
 <http://d-nb.info/gnd/14216075X> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Bilau, Wilhelmine, 1787-1805" .
-<http://d-nb.info/gnd/143102893> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Sanda, Dominique, 1951-" .
 <http://d-nb.info/gnd/143102893> <http://d-nb.info/standards/elementset/gnd#preferredName> "Sanda, Dominique, 1951-" .
+<http://d-nb.info/gnd/143102893> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Sanda, Dominique, 1951-" .
 <http://d-nb.info/gnd/14320713X> <http://d-nb.info/standards/elementset/gnd#preferredName> "Blum, Richard, 1962-" .
 <http://d-nb.info/gnd/14320713X> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Blum, Richard, 1962-" .
 <http://d-nb.info/gnd/159865794> <http://d-nb.info/standards/elementset/gnd#preferredName> "Adenauer, Konrad" .
@@ -150,42 +150,42 @@
 <http://d-nb.info/gnd/16080300-7> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Entwicklungsagentur Rheinland-Pfalz" .
 <http://d-nb.info/gnd/172026644> <http://d-nb.info/standards/elementset/gnd#preferredName> "Courtillon, Janine" .
 <http://d-nb.info/gnd/172026644> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Courtillon, Janine" .
-<http://d-nb.info/gnd/174423330> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Job, Bertram" .
 <http://d-nb.info/gnd/174423330> <http://d-nb.info/standards/elementset/gnd#preferredName> "Job, Bertram" .
+<http://d-nb.info/gnd/174423330> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Job, Bertram" .
 <http://d-nb.info/gnd/174737203> <http://d-nb.info/standards/elementset/gnd#preferredName> "Aigner, Johann" .
 <http://d-nb.info/gnd/174737203> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Aigner, Johann" .
-<http://d-nb.info/gnd/175894612> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Hoefler, Angelika" .
 <http://d-nb.info/gnd/175894612> <http://d-nb.info/standards/elementset/gnd#preferredName> "Hoefler, Angelika" .
-<http://d-nb.info/gnd/177005009> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Piprek, Jan" .
+<http://d-nb.info/gnd/175894612> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Hoefler, Angelika" .
 <http://d-nb.info/gnd/177005009> <http://d-nb.info/standards/elementset/gnd#preferredName> "Piprek, Jan" .
-<http://d-nb.info/gnd/177572388> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "SCHOLLE, ROGER H." .
+<http://d-nb.info/gnd/177005009> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Piprek, Jan" .
 <http://d-nb.info/gnd/177572388> <http://d-nb.info/standards/elementset/gnd#preferredName> "SCHOLLE, ROGER H." .
-<http://d-nb.info/gnd/183839064> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Herrenbr\u00FCck, Erika" .
+<http://d-nb.info/gnd/177572388> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "SCHOLLE, ROGER H." .
 <http://d-nb.info/gnd/183839064> <http://d-nb.info/standards/elementset/gnd#preferredName> "Herrenbr\u00FCck, Erika" .
-<http://d-nb.info/gnd/186186193> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Kim, Richard" .
+<http://d-nb.info/gnd/183839064> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Herrenbr\u00FCck, Erika" .
 <http://d-nb.info/gnd/186186193> <http://d-nb.info/standards/elementset/gnd#preferredName> "Kim, Richard" .
+<http://d-nb.info/gnd/186186193> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Kim, Richard" .
 <http://d-nb.info/gnd/186931808> <http://d-nb.info/standards/elementset/gnd#preferredName> "Buchmann, Helmut" .
 <http://d-nb.info/gnd/186931808> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Buchmann, Helmut" .
+<http://d-nb.info/gnd/2005535-3> <http://d-nb.info/standards/elementset/gnd#preferredName> "<<The>> Beatles" .
 <http://d-nb.info/gnd/2005535-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody> "<<The>> Beatles" .
 <http://d-nb.info/gnd/2005535-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "<<The>> Beatles" .
-<http://d-nb.info/gnd/2005535-3> <http://d-nb.info/standards/elementset/gnd#preferredName> "<<The>> Beatles" .
-<http://d-nb.info/gnd/2019209-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Regierungsbezirk M\u00FCnster, Westfalen" .
 <http://d-nb.info/gnd/2019209-5> <http://d-nb.info/standards/elementset/gnd#preferredName> "Regierungsbezirk M\u00FCnster, Westfalen" .
+<http://d-nb.info/gnd/2019209-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Regierungsbezirk M\u00FCnster, Westfalen" .
+<http://d-nb.info/gnd/2023669-4> <http://d-nb.info/standards/elementset/gnd#preferredName> "United Nations" .
 <http://d-nb.info/gnd/2023669-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody> "United Nations" .
 <http://d-nb.info/gnd/2023669-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "United Nations" .
-<http://d-nb.info/gnd/2023669-4> <http://d-nb.info/standards/elementset/gnd#preferredName> "United Nations" .
-<http://d-nb.info/gnd/2037247-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Main-Kinzig-Kreis" .
 <http://d-nb.info/gnd/2037247-4> <http://d-nb.info/standards/elementset/gnd#preferredName> "Main-Kinzig-Kreis" .
-<http://d-nb.info/gnd/2041907-7> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody> "Verein f\u00FCr Leibes\u00FCbungen Borussia 1900 M\u00F6nchengladbach" .
+<http://d-nb.info/gnd/2037247-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Main-Kinzig-Kreis" .
 <http://d-nb.info/gnd/2041907-7> <http://d-nb.info/standards/elementset/gnd#preferredName> "Verein f\u00FCr Leibes\u00FCbungen Borussia 1900 M\u00F6nchengladbach" .
+<http://d-nb.info/gnd/2041907-7> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody> "Verein f\u00FCr Leibes\u00FCbungen Borussia 1900 M\u00F6nchengladbach" .
 <http://d-nb.info/gnd/2050419-6> <http://d-nb.info/standards/elementset/gnd#preferredName> "1. Fu\u00DFball-Club K\u00F6ln 01/07" .
 <http://d-nb.info/gnd/2050419-6> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody> "1. Fu\u00DFball-Club K\u00F6ln 01/07" .
+<http://d-nb.info/gnd/2056181-7> <http://d-nb.info/standards/elementset/gnd#preferredName> "Provinzialinstitut f\u00FCr Westf\u00E4lische Landes- und Volksforschung" .
 <http://d-nb.info/gnd/2056181-7> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody> "Provinzialinstitut f\u00FCr Westf\u00E4lische Landes- und Volksforschung" .
 <http://d-nb.info/gnd/2056181-7> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Provinzialinstitut f\u00FCr Westf\u00E4lische Landes- und Volksforschung" .
-<http://d-nb.info/gnd/2056181-7> <http://d-nb.info/standards/elementset/gnd#preferredName> "Provinzialinstitut f\u00FCr Westf\u00E4lische Landes- und Volksforschung" .
+<http://d-nb.info/gnd/2092393-4> <http://d-nb.info/standards/elementset/gnd#preferredName> "Rheinland-Pfalz <Koblenz>" .
 <http://d-nb.info/gnd/2092393-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody> "Rheinland-Pfalz <Koblenz>" .
 <http://d-nb.info/gnd/2092393-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Rheinland-Pfalz <Koblenz>" .
-<http://d-nb.info/gnd/2092393-4> <http://d-nb.info/standards/elementset/gnd#preferredName> "Rheinland-Pfalz <Koblenz>" .
 <http://d-nb.info/gnd/2095440-2> <http://d-nb.info/standards/elementset/gnd#preferredName> "Evangelische Kirche von Westfalen" .
 <http://d-nb.info/gnd/2095440-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody> "Evangelische Kirche von Westfalen" .
 <http://d-nb.info/gnd/2095440-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Evangelische Kirche von Westfalen" .
@@ -203,114 +203,114 @@
 <http://d-nb.info/gnd/4003988-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Automobilsport" .
 <http://d-nb.info/gnd/4010355-9> <http://d-nb.info/standards/elementset/gnd#preferredName> "Coesfeld" .
 <http://d-nb.info/gnd/4010355-9> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Coesfeld" .
-<http://d-nb.info/gnd/4010356-0> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Kreis Coesfeld" .
 <http://d-nb.info/gnd/4010356-0> <http://d-nb.info/standards/elementset/gnd#preferredName> "Kreis Coesfeld" .
+<http://d-nb.info/gnd/4010356-0> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Kreis Coesfeld" .
 <http://d-nb.info/gnd/4011882-4> <http://d-nb.info/standards/elementset/gnd#preferredName> "Deutschland" .
 <http://d-nb.info/gnd/4011882-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Deutschland" .
 <http://d-nb.info/gnd/4013255-9> <http://d-nb.info/standards/elementset/gnd#preferredName> "D\u00FCsseldorf" .
 <http://d-nb.info/gnd/4013255-9> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "D\u00FCsseldorf" .
 <http://d-nb.info/gnd/4014228-0> <http://d-nb.info/standards/elementset/gnd#preferredName> "Elektrizit\u00E4tswirtschaft" .
 <http://d-nb.info/gnd/4014228-0> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Elektrizit\u00E4tswirtschaft" .
+<http://d-nb.info/gnd/4018466-3> <http://d-nb.info/standards/elementset/gnd#preferredName> "Freudenberg, Kreis Siegen-Wittgenstein" .
 <http://d-nb.info/gnd/4018466-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Freudenberg, Kreis Siegen-Wittgenstein" .
 <http://d-nb.info/gnd/4018466-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Freudenberg" .
-<http://d-nb.info/gnd/4018466-3> <http://d-nb.info/standards/elementset/gnd#preferredName> "Freudenberg, Kreis Siegen-Wittgenstein" .
-<http://d-nb.info/gnd/4020378-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Germanen" .
 <http://d-nb.info/gnd/4020378-5> <http://d-nb.info/standards/elementset/gnd#preferredName> "Germanen" .
-<http://d-nb.info/gnd/4020517-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Geschichte" .
+<http://d-nb.info/gnd/4020378-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Germanen" .
 <http://d-nb.info/gnd/4020517-4> <http://d-nb.info/standards/elementset/gnd#preferredName> "Geschichte" .
-<http://d-nb.info/gnd/4020533-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Geschichtsunterricht" .
+<http://d-nb.info/gnd/4020517-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Geschichte" .
 <http://d-nb.info/gnd/4020533-2> <http://d-nb.info/standards/elementset/gnd#preferredName> "Geschichtsunterricht" .
-<http://d-nb.info/gnd/4024116-6> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Heimatkundeunterricht" .
+<http://d-nb.info/gnd/4020533-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Geschichtsunterricht" .
 <http://d-nb.info/gnd/4024116-6> <http://d-nb.info/standards/elementset/gnd#preferredName> "Heimatkundeunterricht" .
-<http://d-nb.info/gnd/4034268-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Landesplanung" .
+<http://d-nb.info/gnd/4024116-6> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Heimatkundeunterricht" .
 <http://d-nb.info/gnd/4034268-2> <http://d-nb.info/standards/elementset/gnd#preferredName> "Landesplanung" .
-<http://d-nb.info/gnd/4037117-7> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Main-Kinzig-Kreis" .
+<http://d-nb.info/gnd/4034268-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Landesplanung" .
 <http://d-nb.info/gnd/4037117-7> <http://d-nb.info/standards/elementset/gnd#preferredName> "Main-Kinzig-Kreis" .
+<http://d-nb.info/gnd/4037117-7> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Main-Kinzig-Kreis" .
 <http://d-nb.info/gnd/4040613-1> <http://d-nb.info/standards/elementset/gnd#preferredName> "Bezirk M\u00FCnster (Westf)" .
 <http://d-nb.info/gnd/4040613-1> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Bezirk M\u00FCnster (Westf)" .
-<http://d-nb.info/gnd/4040619-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "M\u00FCnsterland" .
 <http://d-nb.info/gnd/4040619-2> <http://d-nb.info/standards/elementset/gnd#preferredName> "M\u00FCnsterland" .
-<http://d-nb.info/gnd/4040629-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "M\u00FCnze" .
+<http://d-nb.info/gnd/4040619-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "M\u00FCnsterland" .
 <http://d-nb.info/gnd/4040629-5> <http://d-nb.info/standards/elementset/gnd#preferredName> "M\u00FCnze" .
-<http://d-nb.info/gnd/4042203-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Niederlande" .
+<http://d-nb.info/gnd/4040629-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "M\u00FCnze" .
 <http://d-nb.info/gnd/4042203-3> <http://d-nb.info/standards/elementset/gnd#preferredName> "Niederlande" .
-<http://d-nb.info/gnd/4042552-6> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Nordkirchen" .
+<http://d-nb.info/gnd/4042203-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Niederlande" .
 <http://d-nb.info/gnd/4042552-6> <http://d-nb.info/standards/elementset/gnd#preferredName> "Nordkirchen" .
-<http://d-nb.info/gnd/4042570-8> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Nordrhein-Westfalen" .
+<http://d-nb.info/gnd/4042552-6> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Nordkirchen" .
 <http://d-nb.info/gnd/4042570-8> <http://d-nb.info/standards/elementset/gnd#preferredName> "Nordrhein-Westfalen" .
-<http://d-nb.info/gnd/4046259-6> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Plasmaphysik" .
+<http://d-nb.info/gnd/4042570-8> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Nordrhein-Westfalen" .
 <http://d-nb.info/gnd/4046259-6> <http://d-nb.info/standards/elementset/gnd#preferredName> "Plasmaphysik" .
-<http://d-nb.info/gnd/4046277-8> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Plastik" .
+<http://d-nb.info/gnd/4046259-6> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Plasmaphysik" .
 <http://d-nb.info/gnd/4046277-8> <http://d-nb.info/standards/elementset/gnd#preferredName> "Plastik" .
-<http://d-nb.info/gnd/4049716-1> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Rezeption" .
+<http://d-nb.info/gnd/4046277-8> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Plastik" .
 <http://d-nb.info/gnd/4049716-1> <http://d-nb.info/standards/elementset/gnd#preferredName> "Rezeption" .
-<http://d-nb.info/gnd/4049787-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Rhein-Lahn-Kreis" .
+<http://d-nb.info/gnd/4049716-1> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Rezeption" .
 <http://d-nb.info/gnd/4049787-2> <http://d-nb.info/standards/elementset/gnd#preferredName> "Rhein-Lahn-Kreis" .
-<http://d-nb.info/gnd/4049788-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Rheinland" .
+<http://d-nb.info/gnd/4049787-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Rhein-Lahn-Kreis" .
 <http://d-nb.info/gnd/4049788-4> <http://d-nb.info/standards/elementset/gnd#preferredName> "Rheinland" .
-<http://d-nb.info/gnd/4050698-8> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Rothenburg ob der Tauber" .
+<http://d-nb.info/gnd/4049788-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Rheinland" .
 <http://d-nb.info/gnd/4050698-8> <http://d-nb.info/standards/elementset/gnd#preferredName> "Rothenburg ob der Tauber" .
-<http://d-nb.info/gnd/4052945-9> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Schmuck" .
+<http://d-nb.info/gnd/4050698-8> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Rothenburg ob der Tauber" .
 <http://d-nb.info/gnd/4052945-9> <http://d-nb.info/standards/elementset/gnd#preferredName> "Schmuck" .
-<http://d-nb.info/gnd/4065781-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Westfalen" .
+<http://d-nb.info/gnd/4052945-9> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Schmuck" .
 <http://d-nb.info/gnd/4065781-4> <http://d-nb.info/standards/elementset/gnd#preferredName> "Westfalen" .
-<http://d-nb.info/gnd/4067488-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Zeitschrift" .
+<http://d-nb.info/gnd/4065781-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Westfalen" .
 <http://d-nb.info/gnd/4067488-5> <http://d-nb.info/standards/elementset/gnd#preferredName> "Zeitschrift" .
-<http://d-nb.info/gnd/4073757-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Kraftfahrzeug" .
+<http://d-nb.info/gnd/4067488-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Zeitschrift" .
 <http://d-nb.info/gnd/4073757-3> <http://d-nb.info/standards/elementset/gnd#preferredName> "Kraftfahrzeug" .
-<http://d-nb.info/gnd/4073972-7> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Landeskunde" .
+<http://d-nb.info/gnd/4073757-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Kraftfahrzeug" .
 <http://d-nb.info/gnd/4073972-7> <http://d-nb.info/standards/elementset/gnd#preferredName> "Landeskunde" .
-<http://d-nb.info/gnd/4075561-7> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Oberrheinisches Tiefland" .
+<http://d-nb.info/gnd/4073972-7> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Landeskunde" .
 <http://d-nb.info/gnd/4075561-7> <http://d-nb.info/standards/elementset/gnd#preferredName> "Oberrheinisches Tiefland" .
-<http://d-nb.info/gnd/4076769-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "R\u00F6merzeit" .
+<http://d-nb.info/gnd/4075561-7> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Oberrheinisches Tiefland" .
 <http://d-nb.info/gnd/4076769-3> <http://d-nb.info/standards/elementset/gnd#preferredName> "R\u00F6merzeit" .
+<http://d-nb.info/gnd/4076769-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "R\u00F6merzeit" .
 <http://d-nb.info/gnd/4113292-0> <http://d-nb.info/standards/elementset/gnd#preferredName> "Deutsch" .
 <http://d-nb.info/gnd/4113292-0> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Deutsch" .
-<http://d-nb.info/gnd/4114067-9> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Jakobsweg" .
 <http://d-nb.info/gnd/4114067-9> <http://d-nb.info/standards/elementset/gnd#preferredName> "Jakobsweg" .
-<http://d-nb.info/gnd/4115393-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Niedersachsen" .
+<http://d-nb.info/gnd/4114067-9> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Jakobsweg" .
 <http://d-nb.info/gnd/4115393-5> <http://d-nb.info/standards/elementset/gnd#preferredName> "Niedersachsen, S\u00FCd" .
-<http://d-nb.info/gnd/4120314-8> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Polnisch" .
+<http://d-nb.info/gnd/4115393-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Niedersachsen" .
 <http://d-nb.info/gnd/4120314-8> <http://d-nb.info/standards/elementset/gnd#preferredName> "Polnisch" .
+<http://d-nb.info/gnd/4120314-8> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Polnisch" .
 <http://d-nb.info/gnd/4124796-6> <http://d-nb.info/standards/elementset/gnd#preferredName> "Dramaturgie" .
 <http://d-nb.info/gnd/4124796-6> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Dramaturgie" .
-<http://d-nb.info/gnd/4126078-8> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "M\u00FCnzfund" .
 <http://d-nb.info/gnd/4126078-8> <http://d-nb.info/standards/elementset/gnd#preferredName> "M\u00FCnzfund" .
-<http://d-nb.info/gnd/4127794-6> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Heimatkunde" .
+<http://d-nb.info/gnd/4126078-8> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "M\u00FCnzfund" .
 <http://d-nb.info/gnd/4127794-6> <http://d-nb.info/standards/elementset/gnd#preferredName> "Heimatkunde" .
-<http://d-nb.info/gnd/4137215-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Staat Berg" .
+<http://d-nb.info/gnd/4127794-6> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Heimatkunde" .
 <http://d-nb.info/gnd/4137215-3> <http://d-nb.info/standards/elementset/gnd#preferredName> "Staat Berg" .
+<http://d-nb.info/gnd/4137215-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Staat Berg" .
 <http://d-nb.info/gnd/4151183-9> <http://d-nb.info/standards/elementset/gnd#preferredName> "Eigent\u00FCmer" .
 <http://d-nb.info/gnd/4151183-9> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Eigent\u00FCmer" .
-<http://d-nb.info/gnd/4156127-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Geb\u00E4ude" .
 <http://d-nb.info/gnd/4156127-2> <http://d-nb.info/standards/elementset/gnd#preferredName> "Geb\u00E4ude" .
-<http://d-nb.info/gnd/4159648-1> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Herrscherbild" .
+<http://d-nb.info/gnd/4156127-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Geb\u00E4ude" .
 <http://d-nb.info/gnd/4159648-1> <http://d-nb.info/standards/elementset/gnd#preferredName> "Herrscherbild" .
-<http://d-nb.info/gnd/4184194-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Symbolik" .
+<http://d-nb.info/gnd/4159648-1> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Herrscherbild" .
 <http://d-nb.info/gnd/4184194-3> <http://d-nb.info/standards/elementset/gnd#preferredName> "Symbolik" .
-<http://d-nb.info/gnd/4207786-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody> "Steyr-Daimler-Puch AG" .
+<http://d-nb.info/gnd/4184194-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Symbolik" .
 <http://d-nb.info/gnd/4207786-2> <http://d-nb.info/standards/elementset/gnd#preferredName> "Steyr-Daimler-Puch AG" .
-<http://d-nb.info/gnd/4306876-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Regionalplan" .
+<http://d-nb.info/gnd/4207786-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody> "Steyr-Daimler-Puch AG" .
 <http://d-nb.info/gnd/4306876-5> <http://d-nb.info/standards/elementset/gnd#preferredName> "Regionalplan" .
-<http://d-nb.info/gnd/4337730-0> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "LINUX" .
+<http://d-nb.info/gnd/4306876-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Regionalplan" .
 <http://d-nb.info/gnd/4337730-0> <http://d-nb.info/standards/elementset/gnd#preferredName> "LINUX" .
+<http://d-nb.info/gnd/4337730-0> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "LINUX" .
 <http://d-nb.info/gnd/4443675-0> <http://d-nb.info/standards/elementset/gnd#preferredName> "Daimler, Marke" .
 <http://d-nb.info/gnd/4443675-0> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Daimler, Marke" .
-<http://d-nb.info/gnd/4511937-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Online-Publikation" .
 <http://d-nb.info/gnd/4511937-5> <http://d-nb.info/standards/elementset/gnd#preferredName> "Online-Publikation" .
-<http://d-nb.info/gnd/4576855-9> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Steyr, Marke" .
+<http://d-nb.info/gnd/4511937-5> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Online-Publikation" .
 <http://d-nb.info/gnd/4576855-9> <http://d-nb.info/standards/elementset/gnd#preferredName> "Steyr, Marke" .
+<http://d-nb.info/gnd/4576855-9> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Steyr, Marke" .
 <http://d-nb.info/gnd/4604932-0> <http://d-nb.info/standards/elementset/gnd#preferredName> "Abbild" .
 <http://d-nb.info/gnd/4604932-0> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Abbild" .
 <http://d-nb.info/gnd/5079636-7> <http://d-nb.info/standards/elementset/gnd#preferredName> "Deutsch-Franz\u00F6sisch-Schweizerische Oberrheinkonferenz" .
 <http://d-nb.info/gnd/5079636-7> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody> "Deutsch-Franz\u00F6sisch-Schweizerische Oberrheinkonferenz" .
 <http://d-nb.info/gnd/5079636-7> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Deutsch-Franz\u00F6sisch-Schweizerische Oberrheinkonferenz" .
-<http://d-nb.info/gnd/5293676-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Homannsche Erben, N\u00FCrnberg" .
 <http://d-nb.info/gnd/5293676-4> <http://d-nb.info/standards/elementset/gnd#preferredName> "Homannsche Erben, N\u00FCrnberg" .
-<http://d-nb.info/gnd/7683386-0> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheWork> "Grabbe, Christian Dietrich: Der Cid" .
+<http://d-nb.info/gnd/5293676-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson> "Homannsche Erben, N\u00FCrnberg" .
 <http://d-nb.info/gnd/7683386-0> <http://d-nb.info/standards/elementset/gnd#preferredName> "Grabbe, Christian Dietrich: Der Cid" .
-<http://d-nb.info/gnd/7684863-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Lutter-Wasserm\u00FChle Roberg" .
+<http://d-nb.info/gnd/7683386-0> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheWork> "Grabbe, Christian Dietrich: Der Cid" .
 <http://d-nb.info/gnd/7684863-2> <http://d-nb.info/standards/elementset/gnd#preferredName> "Lutter-Wasserm\u00FChle Roberg, Harsewinkel" .
+<http://d-nb.info/gnd/7684863-2> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Lutter-Wasserm\u00FChle Roberg" .
 <http://lobid.org/item/HT000009600:DE-260:Z%201009> <http://purl.org/ontology/daia/label> "Z 1009" .
 <http://lobid.org/item/HT000009600:DE-260:Z%201009> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
 <http://lobid.org/item/HT000009600:DE-260:Z%201009> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-260> .
@@ -336,6 +336,41 @@
 <http://lobid.org/item/HT000009600:DE-60:Zs%201545> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-60> .
 <http://lobid.org/item/HT000009600:DE-60:Zs%201545> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT000009600:DE-60:Zs%201545> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-60:Zs%201545/about> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49> <http://purl.org/ontology/daia/label> "Bg 168: 1-2.1948-49" .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49/about> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950> <http://purl.org/ontology/daia/label> "Bg 168: 3.1950" .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950/about> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951> <http://purl.org/ontology/daia/label> "Bg 168: 4.1951" .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951/about> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53> <http://purl.org/ontology/daia/label> "Bg 168: 5-6.11952-53" .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53/about> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954> <http://purl.org/ontology/daia/label> "Bg 168: 7.1954" .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954/about> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955> <http://purl.org/ontology/daia/label> "Bg 168: 8.1955" .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955/about> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956> <http://purl.org/ontology/daia/label> "Bg 168: 9.1956" .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956/about> .
 <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:10.1957> <http://purl.org/ontology/daia/label> "Bg 168:10.1957" .
 <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:10.1957> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
 <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:10.1957> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
@@ -451,41 +486,6 @@
 <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1983> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
 <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1983> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1983> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1983/about> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49> <http://purl.org/ontology/daia/label> "Bg 168: 1-2.1948-49" .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49/about> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950> <http://purl.org/ontology/daia/label> "Bg 168: 3.1950" .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950/about> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951> <http://purl.org/ontology/daia/label> "Bg 168: 4.1951" .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951/about> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53> <http://purl.org/ontology/daia/label> "Bg 168: 5-6.11952-53" .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53/about> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954> <http://purl.org/ontology/daia/label> "Bg 168: 7.1954" .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954/about> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955> <http://purl.org/ontology/daia/label> "Bg 168: 8.1955" .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955/about> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956> <http://purl.org/ontology/daia/label> "Bg 168: 9.1956" .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956/about> .
 <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:23-24.1970-71> <http://purl.org/ontology/daia/label> "Bg 168:23-24.1970-71" .
 <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:23-24.1970-71> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT000009600> .
 <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:23-24.1970-71> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bm3-3> .
@@ -581,6 +581,11 @@
 <http://lobid.org/item/HT001898812:DE-6-033:Ch%20PIPREK%20gro%20pol%202> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-6-033> .
 <http://lobid.org/item/HT001898812:DE-6-033:Ch%20PIPREK%20gro%20pol%202> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT001898812:DE-6-033:Ch%20PIPREK%20gro%20pol%202> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT001898812:DE-6-033:Ch%20PIPREK%20gro%20pol%202/about> .
+<http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033> <http://purl.org/ontology/daia/label> "1 c 33" .
+<http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT001898812> .
+<http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-6-249> .
+<http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033/about> .
 <http://lobid.org/item/HT001898812:DE-61-28:hisa320.p777(2)> <http://purl.org/ontology/daia/label> "hisa320.p777(2)" .
 <http://lobid.org/item/HT001898812:DE-61-28:hisa320.p777(2)> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT001898812> .
 <http://lobid.org/item/HT001898812:DE-61-28:hisa320.p777(2)> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-61-28> .
@@ -596,11 +601,6 @@
 <http://lobid.org/item/HT001898812:DE-61:sla%2Fb4953(2)> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-61> .
 <http://lobid.org/item/HT001898812:DE-61:sla%2Fb4953(2)> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT001898812:DE-61:sla%2Fb4953(2)> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT001898812:DE-61:sla%2Fb4953(2)/about> .
-<http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033> <http://purl.org/ontology/daia/label> "1 c 33" .
-<http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT001898812> .
-<http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-6-249> .
-<http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033/about> .
 <http://lobid.org/item/HT001898812:DE-6:3G%2026297-2> <http://purl.org/ontology/daia/label> "3G 26297-2" .
 <http://lobid.org/item/HT001898812:DE-6:3G%2026297-2> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT001898812> .
 <http://lobid.org/item/HT001898812:DE-6:3G%2026297-2> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-6> .
@@ -651,16 +651,16 @@
 <http://lobid.org/item/HT004381366:DE-6-210:Boe%2070%20-%20%5B2%5D> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-6-210> .
 <http://lobid.org/item/HT004381366:DE-6-210:Boe%2070%20-%20%5B2%5D> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT004381366:DE-6-210:Boe%2070%20-%20%5B2%5D> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT004381366:DE-6-210:Boe%2070%20-%20%5B2%5D/about> .
-<http://lobid.org/item/HT004381366:DE-6:2C%20583-2> <http://purl.org/ontology/daia/label> "2C 583-2" .
-<http://lobid.org/item/HT004381366:DE-6:2C%20583-2> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT004381366> .
-<http://lobid.org/item/HT004381366:DE-6:2C%20583-2> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-6> .
-<http://lobid.org/item/HT004381366:DE-6:2C%20583-2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT004381366:DE-6:2C%20583-2> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT004381366:DE-6:2C%20583-2/about> .
 <http://lobid.org/item/HT004381366:DE-6-A:MG%2023990%2F1-1> <http://purl.org/ontology/daia/label> "MG 23990/1-1" .
 <http://lobid.org/item/HT004381366:DE-6-A:MG%2023990%2F1-1> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT004381366> .
 <http://lobid.org/item/HT004381366:DE-6-A:MG%2023990%2F1-1> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-6-A> .
 <http://lobid.org/item/HT004381366:DE-6-A:MG%2023990%2F1-1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT004381366:DE-6-A:MG%2023990%2F1-1> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT004381366:DE-6-A:MG%2023990%2F1-1/about> .
+<http://lobid.org/item/HT004381366:DE-6:2C%20583-2> <http://purl.org/ontology/daia/label> "2C 583-2" .
+<http://lobid.org/item/HT004381366:DE-6:2C%20583-2> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT004381366> .
+<http://lobid.org/item/HT004381366:DE-6:2C%20583-2> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-6> .
+<http://lobid.org/item/HT004381366:DE-6:2C%20583-2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT004381366:DE-6:2C%20583-2> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT004381366:DE-6:2C%20583-2/about> .
 <http://lobid.org/item/HT004944075:DE-294:ZRC828-43> <http://purl.org/ontology/daia/label> "ZRC828-43" .
 <http://lobid.org/item/HT004944075:DE-294:ZRC828-43> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT004944075> .
 <http://lobid.org/item/HT004944075:DE-294:ZRC828-43> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-294> .
@@ -896,16 +896,16 @@
 <http://lobid.org/item/HT012926727:DE-468:XYG1362(2)> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-468> .
 <http://lobid.org/item/HT012926727:DE-468:XYG1362(2)> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT012926727:DE-468:XYG1362(2)> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT012926727:DE-468:XYG1362(2)/about> .
-<http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)> <http://purl.org/ontology/daia/label> "PUM 119(2)" .
-<http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT012926727> .
-<http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-51> .
-<http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)/about> .
 <http://lobid.org/item/HT012926727:DE-5-225:R%20278%202001%2F11> <http://purl.org/ontology/daia/label> "R 278 2001/11" .
 <http://lobid.org/item/HT012926727:DE-5-225:R%20278%202001%2F11> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT012926727> .
 <http://lobid.org/item/HT012926727:DE-5-225:R%20278%202001%2F11> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-5-225> .
 <http://lobid.org/item/HT012926727:DE-5-225:R%20278%202001%2F11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT012926727:DE-5-225:R%20278%202001%2F11> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT012926727:DE-5-225:R%20278%202001%2F11/about> .
+<http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)> <http://purl.org/ontology/daia/label> "PUM 119(2)" .
+<http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT012926727> .
+<http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-51> .
+<http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)/about> .
 <http://lobid.org/item/HT012926727:DE-6-017:G%20IV%20a%20132> <http://purl.org/ontology/daia/label> "G IV a 132" .
 <http://lobid.org/item/HT012926727:DE-6-017:G%20IV%20a%20132> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT012926727> .
 <http://lobid.org/item/HT012926727:DE-6-017:G%20IV%20a%20132> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-6-017> .
@@ -1074,16 +1074,16 @@
 <http://lobid.org/item/HT014015351:DE-Dm13:KKZJ%201> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Dm13> .
 <http://lobid.org/item/HT014015351:DE-Dm13:KKZJ%201> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT014015351:DE-Dm13:KKZJ%201> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT014015351:DE-Dm13:KKZJ%201/about> .
-<http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a> <http://purl.org/ontology/daia/label> "deu 503-109a" .
-<http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT014015351> .
-<http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Lan1> .
-<http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a/about> .
 <http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109> <http://purl.org/ontology/daia/label> "deu 503-109" .
 <http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT014015351> .
 <http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Lan1> .
 <http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109/about> .
+<http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a> <http://purl.org/ontology/daia/label> "deu 503-109a" .
+<http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT014015351> .
+<http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Lan1> .
+<http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a/about> .
 <http://lobid.org/item/HT014046679:DE-Bi10:ICE%20Brav> <http://purl.org/ontology/daia/label> "ICE Brav" .
 <http://lobid.org/item/HT014046679:DE-Bi10:ICE%20Brav> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT014046679> .
 <http://lobid.org/item/HT014046679:DE-Bi10:ICE%20Brav> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-Bi10> .
@@ -1154,16 +1154,16 @@
 <http://lobid.org/item/HT015891797:DE-121:09%20A%20756> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-121> .
 <http://lobid.org/item/HT015891797:DE-121:09%20A%20756> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT015891797:DE-121:09%20A%20756> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT015891797:DE-121:09%20A%20756/about> .
-<http://lobid.org/item/HT015891797:DE-38:4E1244-18> <http://purl.org/ontology/daia/label> "4E1244-18" .
-<http://lobid.org/item/HT015891797:DE-38:4E1244-18> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT015891797> .
-<http://lobid.org/item/HT015891797:DE-38:4E1244-18> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-38> .
-<http://lobid.org/item/HT015891797:DE-38:4E1244-18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT015891797:DE-38:4E1244-18> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT015891797:DE-38:4E1244-18/about> .
 <http://lobid.org/item/HT015891797:DE-385:AL.A%2Fsb21613L-2> <http://purl.org/ontology/daia/label> "AL.A/sb21613L-2" .
 <http://lobid.org/item/HT015891797:DE-385:AL.A%2Fsb21613L-2> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT015891797> .
 <http://lobid.org/item/HT015891797:DE-385:AL.A%2Fsb21613L-2> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-385> .
 <http://lobid.org/item/HT015891797:DE-385:AL.A%2Fsb21613L-2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT015891797:DE-385:AL.A%2Fsb21613L-2> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT015891797:DE-385:AL.A%2Fsb21613L-2/about> .
+<http://lobid.org/item/HT015891797:DE-38:4E1244-18> <http://purl.org/ontology/daia/label> "4E1244-18" .
+<http://lobid.org/item/HT015891797:DE-38:4E1244-18> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT015891797> .
+<http://lobid.org/item/HT015891797:DE-38:4E1244-18> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-38> .
+<http://lobid.org/item/HT015891797:DE-38:4E1244-18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT015891797:DE-38:4E1244-18> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT015891797:DE-38:4E1244-18/about> .
 <http://lobid.org/item/HT015891797:DE-465:LRKA1168-1,10,2> <http://purl.org/ontology/daia/label> "LRKA1168-1,10,2" .
 <http://lobid.org/item/HT015891797:DE-465:LRKA1168-1,10,2> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT015891797> .
 <http://lobid.org/item/HT015891797:DE-465:LRKA1168-1,10,2> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-465> .
@@ -1203,14 +1203,14 @@
 <http://lobid.org/item/HT015894164:DE-1044:> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-1044> .
 <http://lobid.org/item/HT015894164:DE-1044:> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT015894164:DE-1044:> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT015894164:DE-1044:/about> .
-<http://lobid.org/item/HT015894164:DE-1383a:> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT015894164> .
-<http://lobid.org/item/HT015894164:DE-1383a:> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-1383a> .
-<http://lobid.org/item/HT015894164:DE-1383a:> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT015894164:DE-1383a:> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT015894164:DE-1383a:/about> .
 <http://lobid.org/item/HT015894164:DE-1383:> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT015894164> .
 <http://lobid.org/item/HT015894164:DE-1383:> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-1383> .
 <http://lobid.org/item/HT015894164:DE-1383:> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT015894164:DE-1383:> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT015894164:DE-1383:/about> .
+<http://lobid.org/item/HT015894164:DE-1383a:> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT015894164> .
+<http://lobid.org/item/HT015894164:DE-1383a:> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-1383a> .
+<http://lobid.org/item/HT015894164:DE-1383a:> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT015894164:DE-1383a:> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT015894164:DE-1383a:/about> .
 <http://lobid.org/item/HT015894164:DE-1393-BOT:> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT015894164> .
 <http://lobid.org/item/HT015894164:DE-1393-BOT:> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-1393-BOT> .
 <http://lobid.org/item/HT015894164:DE-1393-BOT:> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
@@ -1369,6 +1369,11 @@
 <http://lobid.org/item/HT016382441:DE-51:TWR%20644> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-51> .
 <http://lobid.org/item/HT016382441:DE-51:TWR%20644> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT016382441:DE-51:TWR%20644> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT016382441:DE-51:TWR%20644/about> .
+<http://lobid.org/item/HT016382441:DE-61:nc%2F18910> <http://purl.org/ontology/daia/label> "nc/18910" .
+<http://lobid.org/item/HT016382441:DE-61:nc%2F18910> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT016382441> .
+<http://lobid.org/item/HT016382441:DE-61:nc%2F18910> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-61> .
+<http://lobid.org/item/HT016382441:DE-61:nc%2F18910> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
+<http://lobid.org/item/HT016382441:DE-61:nc%2F18910> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT016382441:DE-61:nc%2F18910/about> .
 <http://lobid.org/item/HT016382441:DE-6:033%204370%232> <http://purl.org/ontology/daia/label> "033 4370#2" .
 <http://lobid.org/item/HT016382441:DE-6:033%204370%232> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT016382441> .
 <http://lobid.org/item/HT016382441:DE-6:033%204370%232> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-6> .
@@ -1384,11 +1389,6 @@
 <http://lobid.org/item/HT016382441:DE-6:033%204370> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-6> .
 <http://lobid.org/item/HT016382441:DE-6:033%204370> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
 <http://lobid.org/item/HT016382441:DE-6:033%204370> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT016382441:DE-6:033%204370/about> .
-<http://lobid.org/item/HT016382441:DE-61:nc%2F18910> <http://purl.org/ontology/daia/label> "nc/18910" .
-<http://lobid.org/item/HT016382441:DE-61:nc%2F18910> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT016382441> .
-<http://lobid.org/item/HT016382441:DE-61:nc%2F18910> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-61> .
-<http://lobid.org/item/HT016382441:DE-61:nc%2F18910> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocab/frbr/core#Item> .
-<http://lobid.org/item/HT016382441:DE-61:nc%2F18910> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/item/HT016382441:DE-61:nc%2F18910/about> .
 <http://lobid.org/item/HT016382441:DE-929:2011%2F591> <http://purl.org/ontology/daia/label> "2011/591" .
 <http://lobid.org/item/HT016382441:DE-929:2011%2F591> <http://purl.org/vocab/frbr/core#exemplarOf> <http://lobid.org/resource/HT016382441> .
 <http://lobid.org/item/HT016382441:DE-929:2011%2F591> <http://purl.org/vocab/frbr/core#owner> <http://lobid.org/organisation/DE-929> .
@@ -1510,13 +1510,13 @@
 <http://lobid.org/resource/BT000002852> <http://purl.org/lobid/lv#hbzID> "BT000002852" .
 <http://lobid.org/resource/BT000002852> <http://purl.org/lobid/lv#nwbibsubject> <http://purl.org/lobid/nwbib#s240000> .
 <http://lobid.org/resource/BT000002852> <http://purl.org/lobid/lv#subjectChain> "Freudenberg | Kreis Siegen-Wittgenstein | Geschichte" .
-<http://lobid.org/resource/BT000002852> <http://purl.org/lobid/lv#subjectLabel> "Freudenberg Siegen" .
 <http://lobid.org/resource/BT000002852> <http://purl.org/lobid/lv#subjectLabel> "Freudenberg (Siegerland)" .
+<http://lobid.org/resource/BT000002852> <http://purl.org/lobid/lv#subjectLabel> "Freudenberg Siegen" .
 <http://lobid.org/resource/BT000002852> <http://purl.org/lobid/lv#subjectLabel> "Landesgeschichte" .
 <http://lobid.org/resource/BT000002852> <http://purl.org/lobid/lv#subjectLabel> "Ortsgeschichte" .
 <http://lobid.org/resource/BT000002852> <http://purl.org/lobid/lv#subjectLabel> "Regionalgeschichte" .
-<http://lobid.org/resource/BT000002852> <http://purl.org/lobid/lv#subjectLabel> "Stadt Freudenberg" .
 <http://lobid.org/resource/BT000002852> <http://purl.org/lobid/lv#subjectLabel> "Stadt Freudenberg S\u00FCdwestfalen" .
+<http://lobid.org/resource/BT000002852> <http://purl.org/lobid/lv#subjectLabel> "Stadt Freudenberg" .
 <http://lobid.org/resource/BT000002852> <http://purl.org/lobid/lv#subjectLabel> "Zeitgeschichte" .
 <http://lobid.org/resource/BT000002852> <http://purl.org/ontology/holding#collectedBy> <http://lobid.org/resource/NWBib> .
 <http://lobid.org/resource/BT000002852> <http://rdvocab.info/Elements/otherTitleInformation> "wechselvolle Geschichte" .
@@ -1543,12 +1543,12 @@
 <http://lobid.org/resource/BT000003404> <http://purl.org/lobid/lv#nwbibsubject> <http://purl.org/lobid/nwbib#s126000> .
 <http://lobid.org/resource/BT000003404> <http://purl.org/lobid/lv#subjectChain> "Niedersachsen | S\u00FCd | Karte" .
 <http://lobid.org/resource/BT000003404> <http://purl.org/lobid/lv#subjectChain> "Nordrhein-Westfalen | Karte" .
+<http://lobid.org/resource/BT000003404> <http://purl.org/lobid/lv#subjectLabel> "NRW" .
+<http://lobid.org/resource/BT000003404> <http://purl.org/lobid/lv#subjectLabel> "NW" .
 <http://lobid.org/resource/BT000003404> <http://purl.org/lobid/lv#subjectLabel> "Noordrijn-Westfalen" .
 <http://lobid.org/resource/BT000003404> <http://purl.org/lobid/lv#subjectLabel> "Nord-Westphalie" .
 <http://lobid.org/resource/BT000003404> <http://purl.org/lobid/lv#subjectLabel> "Norte-Westfalia" .
 <http://lobid.org/resource/BT000003404> <http://purl.org/lobid/lv#subjectLabel> "North Rhine-Westphalia" .
-<http://lobid.org/resource/BT000003404> <http://purl.org/lobid/lv#subjectLabel> "NRW" .
-<http://lobid.org/resource/BT000003404> <http://purl.org/lobid/lv#subjectLabel> "NW" .
 <http://lobid.org/resource/BT000003404> <http://purl.org/lobid/lv#subjectLabel> "S\u00FCdliches Niedersachsen" .
 <http://lobid.org/resource/BT000003404> <http://purl.org/lobid/lv#subjectLabel> "S\u00FCdniedersachsen" .
 <http://lobid.org/resource/BT000003404> <http://purl.org/ontology/bibo/edition> "10.[Aufl., Ausg.] 1993/94" .
@@ -1557,8 +1557,8 @@
 <http://lobid.org/resource/BT000003404> <http://purl.org/ontology/bibo/volume> "2" .
 <http://lobid.org/resource/BT000003404> <http://purl.org/ontology/holding#collectedBy> <http://lobid.org/resource/NWBib> .
 <http://lobid.org/resource/BT000003404> <http://rdvocab.info/Elements/otherTitleInformation> "Bundesrepublik Deutschland" .
-<http://lobid.org/resource/BT000003404> <http://rdvocab.info/Elements/otherTitleInformation> "mit Ortsverzeichnis" .
 <http://lobid.org/resource/BT000003404> <http://rdvocab.info/Elements/otherTitleInformation> "Nordrhein-Westfalen, Niedersachsen-S\u00FCd" .
+<http://lobid.org/resource/BT000003404> <http://rdvocab.info/Elements/otherTitleInformation> "mit Ortsverzeichnis" .
 <http://lobid.org/resource/BT000003404> <http://rdvocab.info/Elements/placeOfPublication> "Berlin [u.a.]" .
 <http://lobid.org/resource/BT000003404> <http://rdvocab.info/Elements/publicationStatement> "Berlin [u.a.]; Berlin [u.a.]; Reise- u. Verkehrsverl.; Reise- u. Verkehrsverl.; 1993" .
 <http://lobid.org/resource/BT000003404> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -1643,8 +1643,8 @@
 <http://lobid.org/resource/BT000128754> <http://purl.org/lobid/lv#nwbibsubject> <http://purl.org/lobid/nwbib#s736050> .
 <http://lobid.org/resource/BT000128754> <http://purl.org/lobid/lv#subjectChain> "1. Fu\u00DFball-Club K\u00F6ln 01/07 | Geschichte" .
 <http://lobid.org/resource/BT000128754> <http://purl.org/lobid/lv#subjectChain> "Verein f\u00FCr Leibes\u00FCbungen Borussia 1900 M\u00F6nchengladbach | Geschichte" .
-<http://lobid.org/resource/BT000128754> <http://purl.org/lobid/lv#subjectLabel> "1. FC K\u00F6ln" .
 <http://lobid.org/resource/BT000128754> <http://purl.org/lobid/lv#subjectLabel> "1. FC K\u00F6ln 01/07" .
+<http://lobid.org/resource/BT000128754> <http://purl.org/lobid/lv#subjectLabel> "1. FC K\u00F6ln" .
 <http://lobid.org/resource/BT000128754> <http://purl.org/lobid/lv#subjectLabel> "1. Fu\u00DFball-Club K\u00F6ln 01/07 e.V." .
 <http://lobid.org/resource/BT000128754> <http://purl.org/lobid/lv#subjectLabel> "Borussia M\u00F6nchengladbach" .
 <http://lobid.org/resource/BT000128754> <http://purl.org/lobid/lv#subjectLabel> "Erster FC K\u00F6ln" .
@@ -1687,66 +1687,66 @@
 <http://lobid.org/resource/CT003012479> <http://purl.org/dc/terms/source> <http://lobid.org/resource/HT016511663> .
 <http://lobid.org/resource/CT003012479> <http://purl.org/dc/terms/title> "Elise, Gr\u00E4finn von Hillburg" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Annoni, ..." .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "B\u00F6hm, ..." .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "B\u00F6hm, Johann" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "B\u00F6hm, Marianne" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Bilau, ..." .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Bilau, Margarete" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Bilau, Wilhelmine" .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "B\u00F6hm, ..." .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "B\u00F6hm, Johann" .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "b\u00F6hm, madame" .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "B\u00F6hm, Marianne" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Fuchs, ..." .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, ..." .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Carl" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Carl L." .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Carl Ludwig" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Carl Ludwig <<von>>" .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Charles" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Carl Ludwig" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Carl" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Charles L." .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Charles Lewis" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Charles" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, J. G. K." .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Johann G." .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Johann George Carl Ludwig" .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Johann Georg Karl" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Joh. Georg Karl" .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Karl" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Johann G." .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Johann Georg Karl" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Johann George Carl Ludwig" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Karl Ludwig <<von>>" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Karl" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Giesecke, Ludwig" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Gieseke, Carl L." .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Gieseke, Carl Ludwig" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Gieseke, Carl Ludwig <<von>>" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Gieseke, Carl Ludwig" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Gieseke, Charles Lewis" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Gieseke, Karl L." .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Gieseke, Karl Ludwig" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Gieseke, Karl Ludwig <<von>>" .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "kellermann, ..." .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Gieseke, Karl Ludwig" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Metzler, Carl L." .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Metzler, Johann G." .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Metzler, Johann Georg Karl" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Metzler, Johann Georg <<von>>" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Metzler, Johann Georg Karl" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Mezler, Johann G." .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Mezler, Johann Georg" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Mezler, Johann Georg Karl" .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Pepoli, Alessandro" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Mezler, Johann Georg" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Pepoli, Alessandro E." .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Pepoli, Alessandro Ercole" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Pepoli, Alessandro" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Winter, ..." .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Winter, J. P." .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Winter, P." .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Winter, Peter" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Winter, Peter <<von>>" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Winter, Peter" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Winter, Pierre" .
-<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Winter, Pietro" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Winter, Pietro <<de>>" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Winter, Pietro" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "Wintter, P." .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "b\u00F6hm, madame" .
+<http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#contributorLabel> "kellermann, ..." .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#fulltextOnline> <http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125> .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#hbzID> "CT003012479" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Deutsche Schauspieler-Gesellschaft <D\u00FCsseldorf>" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:061:2-46125" .
 <http://lobid.org/resource/CT003012479> <http://purl.org/ontology/bibo/volume> "1805,04,16" .
+<http://lobid.org/resource/CT003012479> <http://rdvocab.info/Elements/otherTitleInformation> "... wird heute Mittwoch den 17ten April die hier anwesende deutsche Schauspieler-Gesellschaft (Zum Letztenmale) die Ehre haben aufzuf\u00FChren ; eine ganz neue gro\u00DFe komische Oper in 2 Aufz\u00FCgen" .
 <http://lobid.org/resource/CT003012479> <http://rdvocab.info/Elements/otherTitleInformation> "Dankrede" .
 <http://lobid.org/resource/CT003012479> <http://rdvocab.info/Elements/otherTitleInformation> "Elisa, Gr\u00E4fin von Hildburg" .
 <http://lobid.org/resource/CT003012479> <http://rdvocab.info/Elements/otherTitleInformation> "Elise, Gr\u00E4fin von Hartburg" .
-<http://lobid.org/resource/CT003012479> <http://rdvocab.info/Elements/otherTitleInformation> "... wird heute Mittwoch den 17ten April die hier anwesende deutsche Schauspieler-Gesellschaft (Zum Letztenmale) die Ehre haben aufzuf\u00FChren ; eine ganz neue gro\u00DFe komische Oper in 2 Aufz\u00FCgen" .
 <http://lobid.org/resource/CT003012479> <http://rdvocab.info/Elements/otherTitleInformation> "Zum Beschlu\u00DF wird Mad. B\u00F6hm d.j. eine Dankrede halten, welche gedruckt an der Kassa zu kaufen ist" .
 <http://lobid.org/resource/CT003012479> <http://rdvocab.info/Elements/placeOfPublication> "D\u00FCsseldorf" .
 <http://lobid.org/resource/CT003012479> <http://rdvocab.info/Elements/placeOfPublication> "[D\u00FCsseldorf]" .
@@ -1760,8 +1760,8 @@
 <http://lobid.org/resource/CT003012479> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DCT003012479> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/elements/1.1/publisher> "DAG" .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/37043-5> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/issued> "1948" .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/issued> "1948 - 1983" .
+<http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/issued> "1948" .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/dc/terms/subject> <http://dewey.info/class/330/> .
@@ -1780,6 +1780,13 @@
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-38:Haa1455> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-464:D%2000%2F49%20Z%2025> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-60:Zs%201545> .
+<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49> .
+<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950> .
+<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951> .
+<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53> .
+<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954> .
+<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955> .
+<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:10.1957> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:11-13.1958-60> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:14-15.1961-62> .
@@ -1796,20 +1803,13 @@
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1975> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1976> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1977> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1978> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1978.86%20Register%20%5BL%5D> .
+<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1978> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1979> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1980> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1981> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1982> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1983> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955> .
-<http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:23-24.1970-71> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bm3:Bg%20168> .
 <http://lobid.org/resource/HT000009600> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT000009600:DE-Bo102:Zs%20371> .
@@ -1827,7 +1827,6 @@
 <http://lobid.org/resource/HT000009600> <http://rdvocab.info/Elements/placeOfPublication> "Hamburg" .
 <http://lobid.org/resource/HT000009600> <http://rdvocab.info/Elements/publicationStatement> "Hamburg; DAG; 1948" .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resource/HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Journal> .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/6211-x> .
 <http://lobid.org/resource/HT000009600> <http://www.w3.org/2002/07/owl#sameAs> <http://lobid.org/resource/ZDB6211-x> .
@@ -1873,7 +1872,6 @@
 <http://lobid.org/resource/HT001310215> <http://rdvocab.info/Elements/placeOfPublication> "CHICAGO, ILL." .
 <http://lobid.org/resource/HT001310215> <http://rdvocab.info/Elements/publicationStatement> "CHICAGO, ILL.; AMERICAN DENTAL ASSOCIATION; 1980" .
 <http://lobid.org/resource/HT001310215> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resource/HT001310215> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resource/HT001310215> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Journal> .
 <http://lobid.org/resource/HT001310215> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT001310215> .
 <http://lobid.org/resource/HT001310215> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT001310215/about> .
@@ -1908,15 +1906,15 @@
 <http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-465:AAEP35-2> .
 <http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-466:AAE1058-2> .
 <http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-466:GYB1007-2> .
-<http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)> .
 <http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%231> .
 <http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%232> .
 <http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%233> .
+<http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)> .
 <http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-6-033:Ch%20PIPREK%20gro%20pol%202> .
+<http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033> .
 <http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-61-28:hisa320.p777(2)> .
 <http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-61:nc%2F01478> .
 <http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-61:sla%2Fb4953(2)> .
-<http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033> .
 <http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-6:3G%2026297-2> .
 <http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-6:3G%2026297A-2> .
 <http://lobid.org/resource/HT001898812> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT001898812:DE-98:V,%2018809%20(2)> .
@@ -1996,8 +1994,8 @@
 <http://lobid.org/resource/HT004381366> <http://purl.org/ontology/holding#collectedBy> <http://lobid.org/resource/NWBib> .
 <http://lobid.org/resource/HT004381366> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT004381366:DE-6-007:Sep.%2010.04.01%2F55,5> .
 <http://lobid.org/resource/HT004381366> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT004381366:DE-6-210:Boe%2070%20-%20%5B2%5D> .
-<http://lobid.org/resource/HT004381366> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT004381366:DE-6:2C%20583-2> .
 <http://lobid.org/resource/HT004381366> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT004381366:DE-6-A:MG%2023990%2F1-1> .
+<http://lobid.org/resource/HT004381366> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT004381366:DE-6:2C%20583-2> .
 <http://lobid.org/resource/HT004381366> <http://rdvocab.info/Elements/placeOfPublication> "M\u00FCnster" .
 <http://lobid.org/resource/HT004381366> <http://rdvocab.info/Elements/publicationStatement> "M\u00FCnster; Der Regierungspr\u00E4sident; 1986" .
 <http://lobid.org/resource/HT004381366> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -2022,15 +2020,15 @@
 <http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Commission Economique pour l'Europe" .
 <http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "ECE" .
 <http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Economic Commission for Europe" .
-<http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Europ\u00E4ische Wirtschaftskommission" .
 <http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Eur\u00F3pai Gazdas\u00E1gi Bizotts\u00E1g" .
+<http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Europ\u00E4ische Wirtschaftskommission" .
 <http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Evropejskaja \u0116konomi\u010Deskaja Komissija" .
-<http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "\u0116konomi\u010Deskaja Komissija dlja Evropy" .
-<http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "UNECE" .
 <http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "UN-ECE" .
+<http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "UNECE" .
 <http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "United Nations" .
 <http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Wirtschaftsausschuss f\u00FCr Europa" .
 <http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Wirtschaftskommission f\u00FCr Europa" .
+<http://lobid.org/resource/HT004944075> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "\u0116konomi\u010Deskaja Komissija dlja Evropy" .
 <http://lobid.org/resource/HT004944075> <http://purl.org/ontology/bibo/isbn13> "9789210162760" .
 <http://lobid.org/resource/HT004944075> <http://purl.org/ontology/bibo/isbn> "9210162765" .
 <http://lobid.org/resource/HT004944075> <http://purl.org/ontology/bibo/volume> "43" .
@@ -2056,14 +2054,13 @@
 <http://lobid.org/resource/HT006266886> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/ita> .
 <http://lobid.org/resource/HT006266886> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/AudioVisualDocument> .
 <http://lobid.org/resource/HT006266886> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1050> .
-<http://lobid.org/resource/HT006266886> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAMediaType/1005> .
 <http://lobid.org/resource/HT006266886> <http://purl.org/dc/terms/title> "Il giardino dei Finzi-Contini" .
 <http://lobid.org/resource/HT006266886> <http://purl.org/lobid/lv#contributorLabel> "Basani, G'org'o" .
 <http://lobid.org/resource/HT006266886> <http://purl.org/lobid/lv#contributorLabel> "Bassani, Giorgio" .
 <http://lobid.org/resource/HT006266886> <http://purl.org/lobid/lv#contributorLabel> "Berger, Helmut" .
 <http://lobid.org/resource/HT006266886> <http://purl.org/lobid/lv#contributorLabel> "Capolicchio, Lino" .
-<http://lobid.org/resource/HT006266886> <http://purl.org/lobid/lv#contributorLabel> "DeSica, Vittorio" .
 <http://lobid.org/resource/HT006266886> <http://purl.org/lobid/lv#contributorLabel> "De Sica, Vittorio" .
+<http://lobid.org/resource/HT006266886> <http://purl.org/lobid/lv#contributorLabel> "DeSica, Vittorio" .
 <http://lobid.org/resource/HT006266886> <http://purl.org/lobid/lv#contributorLabel> "Marchi, Giacomo" .
 <http://lobid.org/resource/HT006266886> <http://purl.org/lobid/lv#contributorLabel> "Sanda, Dominique" .
 <http://lobid.org/resource/HT006266886> <http://purl.org/lobid/lv#contributorLabel> "Sica, Vittorio <<de>>" .
@@ -2100,12 +2097,12 @@
 <http://lobid.org/resource/HT009719670> <http://purl.org/lobid/lv#contributorLabel> "Rohmer, Eric" .
 <http://lobid.org/resource/HT009719670> <http://purl.org/lobid/lv#contributorLabel> "Salins, G. D. <<de>>" .
 <http://lobid.org/resource/HT009719670> <http://purl.org/lobid/lv#contributorLabel> "Salins, Genevi\u00E8ve-Dominique <<de>>" .
-<http://lobid.org/resource/HT009719670> <http://purl.org/lobid/lv#contributorLabel> "Scherer, Henri Joseph" .
-<http://lobid.org/resource/HT009719670> <http://purl.org/lobid/lv#contributorLabel> "Scherer, Maurice" .
-<http://lobid.org/resource/HT009719670> <http://purl.org/lobid/lv#contributorLabel> "Scherer, Maurice Jean-Marie" .
 <http://lobid.org/resource/HT009719670> <http://purl.org/lobid/lv#contributorLabel> "Sch\u00E9rer, Henri Maurice Joseph" .
 <http://lobid.org/resource/HT009719670> <http://purl.org/lobid/lv#contributorLabel> "Sch\u00E9rer, Jean-Marie Maurice" .
 <http://lobid.org/resource/HT009719670> <http://purl.org/lobid/lv#contributorLabel> "Sch\u00E9rer, Maurice Henri Joseph" .
+<http://lobid.org/resource/HT009719670> <http://purl.org/lobid/lv#contributorLabel> "Scherer, Henri Joseph" .
+<http://lobid.org/resource/HT009719670> <http://purl.org/lobid/lv#contributorLabel> "Scherer, Maurice Jean-Marie" .
+<http://lobid.org/resource/HT009719670> <http://purl.org/lobid/lv#contributorLabel> "Scherer, Maurice" .
 <http://lobid.org/resource/HT009719670> <http://purl.org/lobid/lv#hbzID> "HT009719670" .
 <http://lobid.org/resource/HT009719670> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT009719670:DE-467:> .
 <http://lobid.org/resource/HT009719670> <http://rdvocab.info/Elements/frequency> "Erschienen: 1 - 2, jeweils Videokass. u. Begleith." .
@@ -2126,9 +2123,9 @@
 <http://lobid.org/resource/HT010662586> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resource/HT010662586> <http://purl.org/dc/terms/title> "The Common man in the great Civil War" .
 <http://lobid.org/resource/HT010662586> <http://purl.org/lobid/lv#contributorLabel> "C." .
+<http://lobid.org/resource/HT010662586> <http://purl.org/lobid/lv#contributorLabel> "Wedgwood, C. V." .
 <http://lobid.org/resource/HT010662586> <http://purl.org/lobid/lv#contributorLabel> "Wedgwood, Cicely V." .
 <http://lobid.org/resource/HT010662586> <http://purl.org/lobid/lv#contributorLabel> "Wedgwood, Cicely Veronica" .
-<http://lobid.org/resource/HT010662586> <http://purl.org/lobid/lv#contributorLabel> "Wedgwood, C. V." .
 <http://lobid.org/resource/HT010662586> <http://purl.org/lobid/lv#contributorLabel> "Wedgwood, Veronica" .
 <http://lobid.org/resource/HT010662586> <http://purl.org/lobid/lv#hbzID> "HT010662586" .
 <http://lobid.org/resource/HT010662586> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010662586:DE-380:> .
@@ -2147,10 +2144,10 @@
 <http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
-<http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/subject> <http://dewey.info/class/530/> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4046259-6> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4067488-5> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4511937-5> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/subject> <http://dewey.info/class/530/> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/dc/terms/title> "Physics of plasmas" .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#fulltextOnline> <http://www.bibliothek.uni-regensburg.de/ezeit/?1472746> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#hbzID> "HT010726584" .
@@ -2158,10 +2155,10 @@
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectLabel> "Computerdatei im Fernzugriff (Formschlagwort)" .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectLabel> "Netzpublikation" .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectLabel> "On-line-Datenbank (Formschlagwort)" .
-<http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectLabel> "Online-Datenbank (Formschlagwort)" .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectLabel> "On-line-Dokument" .
-<http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectLabel> "Online-Dokument" .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectLabel> "On-line-Publikation" .
+<http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectLabel> "Online-Datenbank (Formschlagwort)" .
+<http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectLabel> "Online-Dokument" .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectLabel> "Online-Ressource" .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectLabel> "Periodikum" .
 <http://lobid.org/resource/HT010726584> <http://purl.org/lobid/lv#subjectLabel> "Zeitschriften" .
@@ -2176,23 +2173,23 @@
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-290:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-294:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-361:> .
-<http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-38:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-385:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-386:> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-38:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-38M:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-464:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-465:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-466:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-467:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-468:> .
-<http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-5:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-51:> .
-<http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-6:> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-5:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-61:> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-6:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-708:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-743:> .
-<http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-82:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-829:> .
+<http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-82:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-832:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-836:> .
 <http://lobid.org/resource/HT010726584> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT010726584:DE-929:> .
@@ -2206,7 +2203,6 @@
 <http://lobid.org/resource/HT010726584> <http://rdvocab.info/Elements/publicationStatement> "[S.l.]; American Institute of Physics; 1994" .
 <http://lobid.org/resource/HT010726584> <http://rdvocab.info/Elements/statementOfResponsibility> "publ. by the American Institute of Physics" .
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resource/HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Journal> .
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/1472746-8> .
 <http://lobid.org/resource/HT010726584> <http://www.w3.org/2002/07/owl#sameAs> <http://lobid.org/resource/ZDB1472746-8> .
@@ -2251,8 +2247,8 @@
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#hbzID> "HT012926727" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectChain> "Deutschland | Elektrizit\u00E4tswirtschaft (21)" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Allemagne (Deutschland)" .
-<http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "BRD" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "BRD (1990-)" .
+<http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "BRD" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Bundesrepublik Deutschland (1990-)" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Deutsche L\u00E4nder" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Deutscher Bund" .
@@ -2263,18 +2259,18 @@
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Elektrischer Strom / Energiewirtschaft" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Elektrizit\u00E4t / Energiewirtschaft" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Elektrizit\u00E4t / Wirtschaft" .
+<http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "FRG" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Federal Republic of Germany (Deutschland)" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Federativnaja Respublika Germanija" .
-<http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "FRG" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Germanija" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Germany (Deutschland)" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Heiliges R\u00F6misches Reich" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Niemcy" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Norddeutscher Bund" .
+<http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "R\u00E9publique F\u00E9d\u00E9rale d'Allemagne (Deutschland)" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Repubblica Federale di Germania (Deutschland)" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Republic of Germany (Deutschland)" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Rheinbund" .
-<http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "R\u00E9publique F\u00E9d\u00E9rale d'Allemagne (Deutschland)" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "Stromwirtschaft" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/lobid/lv#subjectLabel> "\u01E6umh\u016Br\u012Byat Alm\u0101niy\u0101 al-Itti\u1E25\u0101d\u012Bya" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/ontology/bibo/edition> "2. Aufl." .
@@ -2284,22 +2280,22 @@
 <http://lobid.org/resource/HT012926727> <http://purl.org/ontology/bibo/isbn> "9783642631948" .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-1010:01PUM23(2)> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-1042:etech%20A%20002%202.%20Aufl.> .
-<http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B2> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B3> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B4> .
-<http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-294:WQB20673:2> .
+<http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-294:WQB20673%2B1:2> .
+<http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-294:WQB20673:2> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-38:28A2398> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-464:XYG1451(2)%2B1_d> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-464:XYG1451(2)_d> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-464:ZPO41357(2)> .
-<http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-465:ZPH3644(2)> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-465:ZPH3644(2)%2B1> .
-<http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-468:XYG1362(2)> .
+<http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-465:ZPH3644(2)> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-468:XYG1362(2)%2B1> .
-<http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)> .
+<http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-468:XYG1362(2)> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-5-225:R%20278%202001%2F11> .
+<http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-6-017:G%20IV%20a%20132> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-60:XYG1451(2)%2B1_d> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-61-81:jurj354.m946> .
@@ -2312,9 +2308,9 @@
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-Dm13:XYG%206(2)> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-Due62:11%20ZPH%2026%20(2)> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-Due62:16%20ZPH%2026%20(2)%20%2B1> .
-<http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)%2B1> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)%2B2> .
+<http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-Hag4:E%2FZB-Wgm32%2020:2A> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-Hag4:E%2FZB-Wgm32%2020:2B> .
 <http://lobid.org/resource/HT012926727> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT012926727:DE-Hag4:W-Wgm32%2020:2> .
@@ -2351,15 +2347,15 @@
 <http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#nwbibsubject> <http://purl.org/lobid/nwbib#s784080> .
 <http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectChain> "Coesfeld | Heimatkundeunterricht | Lehrmittel (213)" .
 <http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectChain> "Kreis Coesfeld | Heimatkundeunterricht | Lehrmittel (213)" .
-<http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Coesfeld. Hauptamt" .
 <http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Coesfeld (Kreis)" .
+<http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Coesfeld. Hauptamt" .
 <http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Coesfeld. Pressestelle" .
 <http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Coesfeld. Stadtdirektor" .
 <http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Hauptamt (Coesfeld)" .
 <http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Hauptamt (Kreis Coesfeld)" .
-<http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Heimatkundedidaktik" .
-<http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Heimatkunde / Didaktik" .
 <http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Heimatkunde (Unterricht)" .
+<http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Heimatkunde / Didaktik" .
+<http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Heimatkundedidaktik" .
 <http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Kosfel'd" .
 <http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Kreis Coesfeld. Hauptamt" .
 <http://lobid.org/resource/HT013077595> <http://purl.org/lobid/lv#subjectLabel> "Kreis Coesfeld. Kreistag" .
@@ -2387,17 +2383,17 @@
 <http://lobid.org/resource/HT013077595> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT013077595/about> .
 <http://lobid.org/resource/HT013077595> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013077595> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/elements/1.1/publisher> "Ebner" .
-<http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/issued> "2002" .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/issued> "2002 - 2002" .
+<http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/issued> "2002" .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
+<http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4052945-9> .
+<http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4067488-5> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/subject> <http://dewey.info/class/050/> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/subject> <http://dewey.info/class/070/> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/subject> <http://dewey.info/class/620/> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/subject> <http://dewey.info/class/790/> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/subject> <http://dewey.info/class/791/> .
-<http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4052945-9> .
-<http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4067488-5> .
 <http://lobid.org/resource/HT013304490> <http://purl.org/dc/terms/title> "D\u00E9cid\u00E9" .
 <http://lobid.org/resource/HT013304490> <http://purl.org/lobid/lv#hbzID> "HT013304490" .
 <http://lobid.org/resource/HT013304490> <http://purl.org/lobid/lv#subjectChain> "Schmuck | Zeitschrift" .
@@ -2419,7 +2415,6 @@
 <http://lobid.org/resource/HT013304490> <http://rdvocab.info/Elements/placeOfPublication> "Ulm" .
 <http://lobid.org/resource/HT013304490> <http://rdvocab.info/Elements/publicationStatement> "Ulm; Ebner; 2002" .
 <http://lobid.org/resource/HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resource/HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resource/HT013304490> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Journal> .
 <http://lobid.org/resource/HT013304490> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2073588-1> .
 <http://lobid.org/resource/HT013304490> <http://www.w3.org/2002/07/owl#sameAs> <http://lobid.org/resource/ZDB2073588-1> .
@@ -2445,16 +2440,16 @@
 <http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#hbzID> "HT013577568" .
 <http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#nwbibspatial> <http://purl.org/lobid/nwbib-spatial#n03> .
 <http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#nwbibsubject> <http://purl.org/lobid/nwbib#s226040> .
-<http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectChain> "Rheinland" .
-<http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectChain> "Rheinland | R\u00F6merzeit | Germanen | M\u00FCnze | Geschichte 71 v. Chr.-70 v. Chr (23415,34215,43215)" .
 <http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectChain> "R\u00F6merzeit | M\u00FCnzfund | Geschichte 71 v. Chr.-70 v. Chr (2314,3214)" .
+<http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectChain> "Rheinland | R\u00F6merzeit | Germanen | M\u00FCnze | Geschichte 71 v. Chr.-70 v. Chr (23415,34215,43215)" .
+<http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectChain> "Rheinland" .
 <http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectLabel> "Fundm\u00FCnze" .
 <http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectLabel> "Germanische V\u00F6lker" .
-<http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectLabel> "Metallgeld" .
 <http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectLabel> "M\u00FCnzen" .
 <http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectLabel> "M\u00FCnzschatz" .
-<http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectLabel> "Rheinlande (im engeren Sinn)" .
+<http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectLabel> "Metallgeld" .
 <http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectLabel> "R\u00F6mische Zeit" .
+<http://lobid.org/resource/HT013577568> <http://purl.org/lobid/lv#subjectLabel> "Rheinlande (im engeren Sinn)" .
 <http://lobid.org/resource/HT013577568> <http://purl.org/ontology/holding#collectedBy> <http://lobid.org/resource/NWBib> .
 <http://lobid.org/resource/HT013577568> <http://rdvocab.info/Elements/otherTitleInformation> "Mittel- und Niederrhein ca. 70 - 71 v. Chr. anhand germanischer M\u00FCnzen" .
 <http://lobid.org/resource/HT013577568> <http://rdvocab.info/Elements/publicationStatement> "2003" .
@@ -2475,8 +2470,8 @@
 <http://lobid.org/resource/HT013911008> <http://purl.org/dc/terms/title> "1000 Fotos aus Rothenburg ob der Tauber" .
 <http://lobid.org/resource/HT013911008> <http://purl.org/lobid/lv#hbzID> "HT013911008" .
 <http://lobid.org/resource/HT013911008> <http://purl.org/lobid/lv#subjectChain> "Rothenburg ob der Tauber | CD-ROM" .
-<http://lobid.org/resource/HT013911008> <http://purl.org/lobid/lv#subjectLabel> "Rothenburg ob der Tauber" .
 <http://lobid.org/resource/HT013911008> <http://purl.org/lobid/lv#subjectLabel> "Rothenburg o.d.T." .
+<http://lobid.org/resource/HT013911008> <http://purl.org/lobid/lv#subjectLabel> "Rothenburg ob der Tauber" .
 <http://lobid.org/resource/HT013911008> <http://purl.org/lobid/lv#subjectLabel> "Rothenburg, Tauber" .
 <http://lobid.org/resource/HT013911008> <http://purl.org/lobid/lv#subjectLabel> "Stadtmagistrat (Rothenburg, Tauber)" .
 <http://lobid.org/resource/HT013911008> <http://purl.org/ontology/bibo/isbn13> "9783936547047" .
@@ -2571,19 +2566,19 @@
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "Charlemagne (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "Charlemaigne (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "Charlemaine (747-814)" .
-<http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "der Gro\u00DFe (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "Franken, K\u00F6nig (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "Germania, Imperator (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "Heiliges R\u00F6misches Reich, Kaiser (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "Imperium Romanum-Germanicum, Imperator (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "Karlmeinet (747-814)" .
-<http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "le Grand (747-814)" .
+<http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "M\u00F3r (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "Magno (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "Magnus (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "Magnus Germanus (747-814)" .
-<http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "M\u00F3r (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "R\u00F6mischer Kaiser (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "R\u00F6misches Reich, Kaiser I. (747-814)" .
+<http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "der Gro\u00DFe (747-814)" .
+<http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "le Grand (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/lobid/lv#subjectLabel> "the Great (747-814)" .
 <http://lobid.org/resource/HT014215912> <http://purl.org/ontology/holding#collectedBy> <http://lobid.org/resource/NWBib> .
 <http://lobid.org/resource/HT014215912> <http://rdvocab.info/Elements/publicationStatement> "2004" .
@@ -2647,29 +2642,29 @@
 <http://lobid.org/resource/HT014525099> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/AudioDocument> .
 <http://lobid.org/resource/HT014525099> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/mo/Vinyl> .
 <http://lobid.org/resource/HT014525099> <http://purl.org/dc/terms/title> "Kantaten Ostern, Pfingsten" .
-<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Adam, Theo" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Adam, Theo Siegfried" .
+<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Adam, Theo" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Aug\u00E9r, Arleen" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, ..." .
-<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Giovanni Sebastiano" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, G. S." .
+<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Giovanni Sebastiano" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Iogann Sebast\u02B9jan" .
+<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, J. S." .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Jan Sebastian" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Jean S." .
-<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Jean-Sebastien" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Jean-S\u00E9bastien" .
-<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Johannes S." .
-<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Johannes Sebastian" .
+<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Jean-Sebastien" .
+<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Joh. Seb." .
+<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Joh. Sebas." .
+<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Joh. Sebast." .
+<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Joh. Sebastian" .
+<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Joh.-Seb." .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Johann S." .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Johann Seb." .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Johann Sebastian" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Johann-Sebastian" .
-<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Joh. Seb." .
-<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Joh.-Seb." .
-<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Joh. Sebas." .
-<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Joh. Sebast." .
-<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Joh. Sebastian" .
-<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, J. S." .
+<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Johannes S." .
+<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Johannes Sebastian" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Bach, Sebastian" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "O\u017Ee, Arlen" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Rotzsch, Hans J." .
@@ -2678,13 +2673,13 @@
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Schreier, P." .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Schreier, Peter" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Shuraiya, P\u0113t\u0101" .
-<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "\u0160rajer, Peter" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "Wenkel, Ortrun" .
+<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#contributorLabel> "\u0160rajer, Peter" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#hbzID> "HT014525099" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Neues Bach'sches Collegium Musicum" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "New Leipzig Bach Collegium Musicum" .
-<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Thomaner" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Thomaner Chor" .
+<http://lobid.org/resource/HT014525099> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Thomaner" .
 <http://lobid.org/resource/HT014525099> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT014525099:DE-1156:AR%20ba%2071> .
 <http://lobid.org/resource/HT014525099> <http://rdvocab.info/Elements/otherTitleInformation> "Christ lag in Todesbanden BWV 4 ; Ein Herz, da seinen Jesum lebend wei\u00DF BWV 134 ; Erschallet, ihr Lieder BWV 172 ; Also hat Gott die Welt geliebt BWV 68" .
 <http://lobid.org/resource/HT014525099> <http://rdvocab.info/Elements/placeOfPublication> "Berlin" .
@@ -2710,9 +2705,9 @@
 <http://lobid.org/resource/HT014997977> <http://purl.org/lobid/lv#fulltextOnline> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1750752&custom_att_2=simple_viewer> .
 <http://lobid.org/resource/HT014997977> <http://purl.org/lobid/lv#hbzID> "HT014997977" .
 <http://lobid.org/resource/HT014997977> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Arbeitskreis Stra\u00DFenbauabf\u00E4lle Rheinland-Pfalz" .
-<http://lobid.org/resource/HT014997977> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Landesbetrieb Stra\u00DFen und Verkehr Rheinland-Pfalz <Koblenz>" .
-<http://lobid.org/resource/HT014997977> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Landesbetrieb Stra\u00DFen und Verkehr RP" .
 <http://lobid.org/resource/HT014997977> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "LSV" .
+<http://lobid.org/resource/HT014997977> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Landesbetrieb Stra\u00DFen und Verkehr RP" .
+<http://lobid.org/resource/HT014997977> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Landesbetrieb Stra\u00DFen und Verkehr Rheinland-Pfalz <Koblenz>" .
 <http://lobid.org/resource/HT014997977> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Rheinland-Pfalz <Koblenz>" .
 <http://lobid.org/resource/HT014997977> <http://purl.org/ontology/bibo/edition> "1. Aufl." .
 <http://lobid.org/resource/HT014997977> <http://purl.org/ontology/holding#collectedBy> <http://lobid.org/resource/Edoweb> .
@@ -2737,8 +2732,8 @@
 <http://lobid.org/resource/HT015082724> <http://purl.org/dc/terms/issued> "2006" .
 <http://lobid.org/resource/HT015082724> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/nld> .
 <http://lobid.org/resource/HT015082724> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
-<http://lobid.org/resource/HT015082724> <http://purl.org/dc/terms/subject> <http://dewey.info/class/900/> .
 <http://lobid.org/resource/HT015082724> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4042203-3> .
+<http://lobid.org/resource/HT015082724> <http://purl.org/dc/terms/subject> <http://dewey.info/class/900/> .
 <http://lobid.org/resource/HT015082724> <http://purl.org/lobid/lv#hbzID> "HT015082724" .
 <http://lobid.org/resource/HT015082724> <http://purl.org/lobid/lv#subjectChain> "Niederlande | Geschichte | Zeitschrift" .
 <http://lobid.org/resource/HT015082724> <http://purl.org/lobid/lv#subjectLabel> "Batavische Republik" .
@@ -2769,21 +2764,21 @@
 <http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Bruccoli, Matthew J." .
 <http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Bruccoli, Matthew Joseph" .
 <http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Fic\u01C6eralds, Skots Fr\u0101nsiss" .
-<http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Fitzgerald, Francis S." .
-<http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Fitzgerald, Francis Scott" .
-<http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Fitzgerald, Francis Scott Key" .
 <http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Fitzgerald, F. S." .
 <http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Fitzgerald, F. Scott" .
-<http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Fitzgerald, Scott" .
+<http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Fitzgerald, Francis S." .
+<http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Fitzgerald, Francis Scott Key" .
+<http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Fitzgerald, Francis Scott" .
 <http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Fitzgerald, Scott F." .
+<http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Fitzgerald, Scott" .
 <http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Scott Fitzgerald, F." .
 <http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Scott Fitzgerald, Francis" .
 <http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#contributorLabel> "Scott-Fitzgerald, Francis" .
 <http://lobid.org/resource/HT015183529> <http://purl.org/lobid/lv#hbzID> "HT015183529" .
 <http://lobid.org/resource/HT015183529> <http://purl.org/ontology/bibo/edition> "12. print." .
 <http://lobid.org/resource/HT015183529> <http://purl.org/ontology/bibo/editor> <http://d-nb.info/gnd/119468476> .
-<http://lobid.org/resource/HT015183529> <http://purl.org/ontology/bibo/isbn> "0521402301" .
 <http://lobid.org/resource/HT015183529> <http://purl.org/ontology/bibo/isbn13> "9780521402309" .
+<http://lobid.org/resource/HT015183529> <http://purl.org/ontology/bibo/isbn> "0521402301" .
 <http://lobid.org/resource/HT015183529> <http://purl.org/ontology/bibo/isbn> "9780521402309" .
 <http://lobid.org/resource/HT015183529> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015183529:DE-5:2007%2F4575> .
 <http://lobid.org/resource/HT015183529> <http://rdvocab.info/Elements/placeOfPublication> "Cambridge [u.a.]" .
@@ -2826,7 +2821,6 @@
 <http://lobid.org/resource/HT015455455> <http://purl.org/dc/terms/issued> "2007" .
 <http://lobid.org/resource/HT015455455> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resource/HT015455455> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
-<http://lobid.org/resource/HT015455455> <http://purl.org/dc/terms/subject> <http://dewey.info/class/330/> .
 <http://lobid.org/resource/HT015455455> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/118595881> .
 <http://lobid.org/resource/HT015455455> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/2101246-5> .
 <http://lobid.org/resource/HT015455455> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4003988-2> .
@@ -2834,6 +2828,7 @@
 <http://lobid.org/resource/HT015455455> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4207786-2> .
 <http://lobid.org/resource/HT015455455> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4443675-0> .
 <http://lobid.org/resource/HT015455455> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4576855-9> .
+<http://lobid.org/resource/HT015455455> <http://purl.org/dc/terms/subject> <http://dewey.info/class/330/> .
 <http://lobid.org/resource/HT015455455> <http://purl.org/dc/terms/title> "Austro-Daimler und Steyr" .
 <http://lobid.org/resource/HT015455455> <http://purl.org/lobid/lv#contributorLabel> "Pfundner, Martin" .
 <http://lobid.org/resource/HT015455455> <http://purl.org/lobid/lv#hbzID> "HT015455455" .
@@ -2911,8 +2906,8 @@
 <http://lobid.org/resource/HT015891797> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/11850066X> .
 <http://lobid.org/resource/HT015891797> <http://purl.org/dc/terms/title> "September 1965 - April 1967" .
 <http://lobid.org/resource/HT015891797> <http://purl.org/lobid/lv#contributorLabel> "Adenauer, ..." .
-<http://lobid.org/resource/HT015891797> <http://purl.org/lobid/lv#contributorLabel> "Adenauer, Konrad" .
 <http://lobid.org/resource/HT015891797> <http://purl.org/lobid/lv#contributorLabel> "Adenauer, Konrad Hermann Joseph" .
+<http://lobid.org/resource/HT015891797> <http://purl.org/lobid/lv#contributorLabel> "Adenauer, Konrad" .
 <http://lobid.org/resource/HT015891797> <http://purl.org/lobid/lv#hbzID> "HT015891797" .
 <http://lobid.org/resource/HT015891797> <http://purl.org/lobid/lv#subjectChain> "Adenauer, Konrad | Geschichte 1963-1967 | Quelle" .
 <http://lobid.org/resource/HT015891797> <http://purl.org/lobid/lv#subjectLabel> "Adenauer, ... (1876-1967)" .
@@ -2921,8 +2916,8 @@
 <http://lobid.org/resource/HT015891797> <http://purl.org/ontology/holding#collectedBy> <http://lobid.org/resource/NWBib> .
 <http://lobid.org/resource/HT015891797> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015891797:DE-107:9.1191%2F10,2> .
 <http://lobid.org/resource/HT015891797> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015891797:DE-121:09%20A%20756> .
-<http://lobid.org/resource/HT015891797> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015891797:DE-38:4E1244-18> .
 <http://lobid.org/resource/HT015891797> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015891797:DE-385:AL.A%2Fsb21613L-2> .
+<http://lobid.org/resource/HT015891797> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015891797:DE-38:4E1244-18> .
 <http://lobid.org/resource/HT015891797> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015891797:DE-465:LRKA1168-1,10,2> .
 <http://lobid.org/resource/HT015891797> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015891797:DE-468:OTSA1188-2> .
 <http://lobid.org/resource/HT015891797> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015891797:DE-51:LRKA%20101-S,4,2> .
@@ -2956,13 +2951,13 @@
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-1044:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-1383:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-1383a:> .
-<http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-1393:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-1393-BOT:> .
+<http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-1393:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-290:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-294:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-361:> .
-<http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-38:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-385:> .
+<http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-38:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-464:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-465:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-466:> .
@@ -2970,8 +2965,8 @@
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-5:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-6:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-708:> .
-<http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-82:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-829:> .
+<http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-82:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-832:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-836:> .
 <http://lobid.org/resource/HT015894164> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT015894164:DE-Bm40:> .
@@ -3025,18 +3020,18 @@
 <http://lobid.org/resource/HT016382441> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4337730-0> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027722&custom_att_2=simple_viewer> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/dc/terms/title> "Linux f\u00FCr Dummies" .
-<http://lobid.org/resource/HT016382441> <http://purl.org/lobid/lv#contributorLabel> "Blum, Richard" .
 <http://lobid.org/resource/HT016382441> <http://purl.org/lobid/lv#contributorLabel> "Blum, Richard Kenneth" .
+<http://lobid.org/resource/HT016382441> <http://purl.org/lobid/lv#contributorLabel> "Blum, Richard" .
 <http://lobid.org/resource/HT016382441> <http://purl.org/lobid/lv#hbzID> "HT016382441" .
 <http://lobid.org/resource/HT016382441> <http://purl.org/lobid/lv#subjectChain> "LINUX" .
 <http://lobid.org/resource/HT016382441> <http://purl.org/ontology/bibo/edition> "1. Aufl." .
 <http://lobid.org/resource/HT016382441> <http://purl.org/ontology/bibo/isbn13> "9783527706495" .
 <http://lobid.org/resource/HT016382441> <http://purl.org/ontology/bibo/isbn> "9783527706495" .
-<http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B1> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B2> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B3> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B4> .
+<http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-1044:21%20=%20TWR5408%2B5> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-107:112-2195> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-1393:00%2FTWR6> .
@@ -3045,10 +3040,10 @@
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-467:51TWRF4584> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-467:80TWRF4584-DVD> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-51:TWR%20644> .
-<http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-6:033%204370> .
+<http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-61:nc%2F18910> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-6:033%204370%232> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-6:033%204370%233> .
-<http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-61:nc%2F18910> .
+<http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-6:033%204370> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-929:2011%2F591> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-A96:61%20TWR%201197> .
 <http://lobid.org/resource/HT016382441> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT016382441:DE-Dm13:TWR%201053> .
@@ -3102,19 +3097,19 @@
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Baldwin, Dalton" .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Banville, Teodoro <<de>>" .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Banville, Th. <<de>>" .
-<http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Banville, Th\u00E9odore" .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Banville, Th\u00E9odore <<de>>" .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Banville, Th\u00E9odore Follain <<de>>" .
+<http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Banville, Th\u00E9odore" .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debjussi, Klod" .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debussy, ..." .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debussy, Achille" .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debussy, Achille-Claude" .
-<http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debussy, C." .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debussy, C. A." .
-<http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debussy, Claude" .
+<http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debussy, C." .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debussy, Claude A." .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debussy, Claude Achill" .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debussy, Claude Achille" .
+<http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debussy, Claude" .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debussy, Claude-Achille" .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Debussy, Claudio" .
 <http://lobid.org/resource/HT016608165> <http://purl.org/lobid/lv#contributorLabel> "Follain de Banville, Th\u00E9odore" .
@@ -3141,29 +3136,29 @@
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#hbzID> "HT017468042" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Bureau Geographique de Homann" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Coheredis Homanniani" .
-<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Heritiers de Homann" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Heritiers d'Homann" .
+<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Heritiers de Homann" .
+<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Hom\u00E4nnische Erben" .
+<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Hom\u00E4nnische Officin" .
+<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Hom\u00E4nnischer Verlag" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homaennische Erben" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homan. Hered." .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homann Heredib." .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homann Heredibus" .
+<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homann, Verlag" .
+<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homann-Verlag" .
+<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homanni Heredes" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homanniani Heredes" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homannianis Heredibus" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homannianos Heredes" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homannianus Heredus" .
-<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homanni Heredes" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homannische Buchhandlung" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homannische Erben" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homannische Handlung" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homannische Officin" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homannische Offizin" .
-<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homannsche Erben" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homanns Erben" .
-<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homann-Verlag" .
-<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homann, Verlag" .
-<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Hom\u00E4nnische Erben" .
-<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Hom\u00E4nnische Officin" .
-<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Hom\u00E4nnischer Verlag" .
+<http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Homannsche Erben" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Johann Baptist Homann Erben" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Officina Homanniana" .
 <http://lobid.org/resource/HT017468042> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Verlag Homann" .
@@ -3194,7 +3189,6 @@
 <http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#nwbibsubject> <http://purl.org/lobid/nwbib#s240000> .
 <http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#subjectChain> "D\u00FCsseldorf | Staat Berg | Geschichte 1288-1815 (213)" .
 <http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#subjectLabel> "Berg (Staat)" .
-<http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#subjectLabel> "Djussel'dorf" .
 <http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#subjectLabel> "D\u00FCsseldorf. Hauptamt" .
 <http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#subjectLabel> "D\u00FCsseldorf. Oberb\u00FCrgermeister" .
 <http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#subjectLabel> "D\u00FCsseldorf. Oberstadtdirektor" .
@@ -3204,6 +3198,7 @@
 <http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#subjectLabel> "D\u00FCsseldorf. Ratsversammlung" .
 <http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#subjectLabel> "D\u00FCsseldorf. Stadtverordnetenversammlung" .
 <http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#subjectLabel> "D\u00FCsseldorf. Stadtverwaltung" .
+<http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#subjectLabel> "Djussel'dorf" .
 <http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#subjectLabel> "Ducatus Montensis" .
 <http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#subjectLabel> "Duseerduofu" .
 <http://lobid.org/resource/HT018131501> <http://purl.org/lobid/lv#subjectLabel> "Dyusserudorufu" .
@@ -3246,7 +3241,6 @@
 <http://lobid.org/resource/HT018187026> <http://rdvocab.info/Elements/placeOfPublication> "Berlin" .
 <http://lobid.org/resource/HT018187026> <http://rdvocab.info/Elements/publicationStatement> "Berlin; Logos-Verl.; 2013" .
 <http://lobid.org/resource/HT018187026> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resource/HT018187026> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resource/HT018187026> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Series> .
 <http://lobid.org/resource/HT018187026> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018187026> .
 <http://lobid.org/resource/HT018187026> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resource/HT018187026/about> .
@@ -3297,21 +3291,21 @@
 <http://lobid.org/resource/HT018585406> <http://purl.org/dc/terms/title> "Endbericht Workshop Der Oberrhein als Europ\u00E4ische Metropolregion" .
 <http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#contributorLabel> "Clev, Hans-G\u00FCnther" .
 <http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#hbzID> "HT018585406" .
-<http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Conf\u00E9rence du Rhin Sup\u00E9rieur" .
 <http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Conf\u00E9rence Franco-Germano-Suisse du Rhin Sup\u00E9rieur" .
+<http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Conf\u00E9rence du Rhin Sup\u00E9rieur" .
 <http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Deutsch-Franz\u00F6sisch-Schweizerische Oberrheinkonferenz" .
-<http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Entwicklungsagentur Rheinland-Pfalz" .
 <http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Entwicklungsagentur Rheinland-Pfalz e.V." .
-<http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Oberrheinkonferenz" .
+<http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Entwicklungsagentur Rheinland-Pfalz" .
 <http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "ORK" .
+<http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#nameOfContributingCorporateBody> "Oberrheinkonferenz" .
 <http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#subjectChain> "Oberrheinisches Tiefland | Landesplanung" .
 <http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#subjectLabel> "Gebietsplanung" .
 <http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#subjectLabel> "Landesentwicklungsplanung" .
-<http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#subjectLabel> "Oberrheinebene" .
+<http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#subjectLabel> "Oberrhein (Region)" .
 <http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#subjectLabel> "Oberrhein-Gebiet" .
+<http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#subjectLabel> "Oberrheinebene" .
 <http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#subjectLabel> "Oberrheinische Tiefebene" .
 <http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#subjectLabel> "Oberrheinlande" .
-<http://lobid.org/resource/HT018585406> <http://purl.org/lobid/lv#subjectLabel> "Oberrhein (Region)" .
 <http://lobid.org/resource/HT018585406> <http://purl.org/ontology/holding#collectedBy> <http://lobid.org/resource/Edoweb> .
 <http://lobid.org/resource/HT018585406> <http://purl.org/ontology/holding#collectedBy> <http://lobid.org/resource/RPB> .
 <http://lobid.org/resource/HT018585406> <http://purl.org/vocab/frbr/core#exemplar> <http://lobid.org/item/HT018585406:DE-107:> .
@@ -3342,8 +3336,8 @@
 <http://lobid.org/resource/TT000075751> <http://purl.org/lobid/lv#contributorLabel> "Britten, Edward B." .
 <http://lobid.org/resource/TT000075751> <http://purl.org/lobid/lv#contributorLabel> "Britten, Edward Benjamin" .
 <http://lobid.org/resource/TT000075751> <http://purl.org/lobid/lv#contributorLabel> "Lewis, Bryn" .
-<http://lobid.org/resource/TT000075751> <http://purl.org/lobid/lv#contributorLabel> "MacDougall, Jamie" .
 <http://lobid.org/resource/TT000075751> <http://purl.org/lobid/lv#contributorLabel> "Mac Dougall, Jamie" .
+<http://lobid.org/resource/TT000075751> <http://purl.org/lobid/lv#contributorLabel> "MacDougall, Jamie" .
 <http://lobid.org/resource/TT000075751> <http://purl.org/lobid/lv#contributorLabel> "Martineau, Malcolm" .
 <http://lobid.org/resource/TT000075751> <http://purl.org/lobid/lv#contributorLabel> "McDougall, Jamie" .
 <http://lobid.org/resource/TT000075751> <http://purl.org/lobid/lv#contributorLabel> "Nathan, Regina" .
@@ -3407,19 +3401,19 @@
 <http://lobid.org/resource/TT001230001> <http://purl.org/dc/terms/title> "Reliqua librorum Friderici II. ... de arte venandi cum avibus" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Albert" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Alberto" .
-<http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Albertus" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Albertus Magnus" .
+<http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Albertus" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Bolstadius, Albertus" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Federico" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Federicus" .
+<http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Fr\u00E9d\u00E9ric" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Frederick" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Fredericus" .
-<http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Friderichus" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Friderichus secundus" .
+<http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Friderichus" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Fridericus" .
-<http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Friedrich" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Friedrich II." .
-<http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Fr\u00E9d\u00E9ric" .
+<http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Friedrich" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Magnus, Albertus" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Manfred" .
 <http://lobid.org/resource/TT001230001> <http://purl.org/lobid/lv#contributorLabel> "Manfredi" .
@@ -3493,14 +3487,14 @@
 <http://lobid.org/resource/TT001726537> <http://purl.org/dc/terms/contributor> <http://d-nb.info/gnd/115541802> .
 <http://lobid.org/resource/TT001726537> <http://purl.org/dc/terms/issued> "1683" .
 <http://lobid.org/resource/TT001726537> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/fra> .
-<http://lobid.org/resource/TT001726537> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/prodManuscript/1002> .
 <http://lobid.org/resource/TT001726537> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
+<http://lobid.org/resource/TT001726537> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/prodManuscript/1002> .
 <http://lobid.org/resource/TT001726537> <http://purl.org/dc/terms/title> "Critique Du Jesuite Secularis\u00E9" .
 <http://lobid.org/resource/TT001726537> <http://purl.org/lobid/lv#contributorLabel> "Maimbourg, ..." .
 <http://lobid.org/resource/TT001726537> <http://purl.org/lobid/lv#contributorLabel> "Maimbourg, Lewis" .
 <http://lobid.org/resource/TT001726537> <http://purl.org/lobid/lv#contributorLabel> "Maimbourg, Louis" .
-<http://lobid.org/resource/TT001726537> <http://purl.org/lobid/lv#contributorLabel> "Maimburgius, Ludovicus" .
 <http://lobid.org/resource/TT001726537> <http://purl.org/lobid/lv#contributorLabel> "Maimburg, Ludwig" .
+<http://lobid.org/resource/TT001726537> <http://purl.org/lobid/lv#contributorLabel> "Maimburgius, Ludovicus" .
 <http://lobid.org/resource/TT001726537> <http://purl.org/lobid/lv#contributorLabel> "Maimburgo, Luigi" .
 <http://lobid.org/resource/TT001726537> <http://purl.org/lobid/lv#contributorLabel> "Maimburgus, Ludovicus" .
 <http://lobid.org/resource/TT001726537> <http://purl.org/lobid/lv#contributorLabel> "Romain, Fran\u00E7ois" .
@@ -3520,9 +3514,9 @@
 <http://lobid.org/resource/TT002234459> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/Map> .
 <http://lobid.org/resource/TT002234459> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
 <http://lobid.org/resource/TT002234459> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
-<http://lobid.org/resource/TT002234459> <http://purl.org/dc/terms/subject> <http://dewey.info/class/914/> .
 <http://lobid.org/resource/TT002234459> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4049787-2> .
 <http://lobid.org/resource/TT002234459> <http://purl.org/dc/terms/subject> <http://d-nb.info/gnd/4114067-9> .
+<http://lobid.org/resource/TT002234459> <http://purl.org/dc/terms/subject> <http://dewey.info/class/914/> .
 <http://lobid.org/resource/TT002234459> <http://purl.org/dc/terms/title> "Jakobswege : der Lahn-Camino" .
 <http://lobid.org/resource/TT002234459> <http://purl.org/lobid/lv#contributorLabel> "Kranz, Heinrich" .
 <http://lobid.org/resource/TT002234459> <http://purl.org/lobid/lv#contributorLabel> "M\u00FCller, Guntram" .
@@ -3552,7 +3546,6 @@
 <http://lobid.org/resource/TT003059252> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
 <http://lobid.org/resource/TT003059252> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/AudioVisualDocument> .
 <http://lobid.org/resource/TT003059252> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1050> .
-<http://lobid.org/resource/TT003059252> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAMediaType/1005> .
 <http://lobid.org/resource/TT003059252> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resource/TT003059252> <http://purl.org/dc/terms/title> "The Beatles" .
 <http://lobid.org/resource/TT003059252> <http://purl.org/lobid/lv#hbzID> "TT003059252" .


### PR DESCRIPTION
See #676.

@dr0i I am not sure whether adding `@typeOnly` to the if-none statement is the way to go or whether rather `@collection` should be added as the resources to be adjusted are mapped to this variable (see [lines 417-430 in morph](https://github.com/lobid/lodmill/blob/master/lodmill-rd/src/main/resources/morph-hbz01-to-lobid.xml#L417-L430)). Beacause `@collection` is set to `@typeOnly` in [line 423](https://github.com/lobid/lodmill/blob/master/lodmill-rd/src/main/resources/morph-hbz01-to-lobid.xml#L423) I thought it might be the best way to add the most "abstract" variable.

(I hope my wording makes sense. I don't know what the common terminology for most things is...)