### PR TITLE
Add checkout and building for every transformation in the loop

### DIFF
--- a/lodmill-rd/doc/scripts/hbz01/startHbz01ToLobidResources.sh
+++ b/lodmill-rd/doc/scripts/hbz01/startHbz01ToLobidResources.sh
@@ -39,10 +39,10 @@ You may give as 8th parameter a file containing a list of filenames. These will 
 fi
 
 cd ../../../
-git checkout $BRANCH
-mvn clean assembly:assembly -DdescriptorId=jar-with-dependencies -DskipTests=true -DskipIntegrationTests
 
 function indexFile() {
+	git checkout $BRANCH
+	mvn clean assembly:assembly -DdescriptorId=jar-with-dependencies -DskipTests=true -DskipIntegrationTests
 	mvn exec:java -Dexec.mainClass="org.lobid.lodmill.run.MabXml2lobidJsonEs" -Dexec.args="$1 $INDEX_NAME $INDEX_ALIAS_SUFFIX $ES_NODE $ES_CLUSTER_NAME $UPDATE_NEWEST_INDEX"
 }
 


### PR DESCRIPTION
It _could_ be that, while a transformation is triggered in the loop, another
build process of another branch changed the jar. So, if the next transformation
in the loop is triggered there would be a false jar. So it's safer to rebuild
the jar every time a transformation is started.
Note:
It may be that two builds are started in parallel. This would break the building.
But this breaking would be more overt (and the chances that they occur are smaller)
than to use a build from a totally different branch.