### PR TITLE
Keep not_analyzed raw field for facetting over coverage

### DIFF
--- a/lodmill-ld/src/main/resources/index-config.json
+++ b/lodmill-ld/src/main/resources/index-config.json
@@ -205,7 +205,13 @@
 										 "properties" : {
 												"@value" : {
 													 "type" : "string",
-													 "analyzer" : "german_analyzer"
+													 "analyzer" : "german_analyzer",
+													 "fields": {
+														"raw": {
+															"type": "string",
+															"index": "not_analyzed"
+														}
+													 }
 												}
 										 }
 									},

--- a/lodmill-rd/src/main/resources/index-config.json
+++ b/lodmill-rd/src/main/resources/index-config.json
@@ -205,7 +205,13 @@
 										 "properties" : {
 												"@value" : {
 													 "type" : "string",
-													 "analyzer" : "german_analyzer"
+													 "analyzer" : "german_analyzer",
+													 "fields": {
+														"raw": {
+															"type": "string",
+															"index": "not_analyzed"
+														}
+													 }
 												}
 										 }
 									},


### PR DESCRIPTION
See https://github.com/hbz/nwbib/issues/221

Deployed to test set on staging, `coverage` analyzed for German:

http://test.lobid.org/resource?nwbibspatial=K%C3%B6ln&format=full
http://test.lobid.org/resource?nwbibspatial=Koeln&format=full

And available as `raw` for facetting:

http://test.lobid.org/resource/facets?field=@graph.http://purl.org/dc/elements/1.1/coverage.@value.raw&size=9999&q=*