### PR TITLE
Remove delimiter "/" for fields 71[01].

### DIFF
--- a/lodmill-rd/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/lodmill-rd/src/main/resources/morph-hbz01-to-lobid.xml
@@ -1262,7 +1262,6 @@
 		</combine>
 		<!-- other subjects -->
 		<data source="71[01][-abcdfz][123].a" name="http://purl.org/lobid/lv#subjectLabel">
-			<split delimiter=" / "/>
 			<replace pattern="&gt;&gt;" with=""/>
 			<replace pattern="&lt;&lt;" with=""/>
 		</data>


### PR DESCRIPTION
See hbz/lobid#312. I tried to run the tests with `mvn clean install -DdescriptorId=jar-with-dependencies -DskipIntegrationTests --settings settings.xml` as written in the [readme](https://github.com/lobid/lodmill/blob/master/README.textile) but get an error.